### PR TITLE
Add batch paper ingest+train pipeline, fallback seeding, configs, and smoke test

### DIFF
--- a/data/models/train.q1-oa-10k.json
+++ b/data/models/train.q1-oa-10k.json
@@ -1,0 +1,15 @@
+{
+  "benchmarkRowsPath": "data/papers/benchmark/current/benchmark.rows.jsonl",
+  "outputRoot": "data/models",
+  "seed": "q1-oa-10k-v1",
+  "threshold": 0.5,
+  "learningRate": 0.04,
+  "epochs": 40,
+  "l2": 0.0005,
+  "minMetrics": {
+    "accuracy": 0.55,
+    "f1": 0.55,
+    "auroc": 0.6
+  },
+  "failOnQualityDrop": true
+}

--- a/data/papers/benchmark.q1-oa-10k.json
+++ b/data/papers/benchmark.q1-oa-10k.json
@@ -1,0 +1,9 @@
+{
+  "inputDatasetPath": "data/papers/datasets/current/papers.jsonl",
+  "outputRoot": "data/papers/benchmark",
+  "maxPairs": 5000,
+  "minTextChars": 500,
+  "allowedLabels": ["human_academic", "ai_transformed"],
+  "maxClassImbalance": 0.1,
+  "failOnValidationError": true
+}

--- a/data/papers/config.q1-oa-10k.json
+++ b/data/papers/config.q1-oa-10k.json
@@ -1,0 +1,33 @@
+{
+  "requestTimeoutMs": 30000,
+  "openAlexQueries": [
+    {
+      "query": "",
+      "fromYear": 2018,
+      "toYear": 2026,
+      "pages": 50,
+      "perPage": 200,
+      "openAccessOnly": true,
+      "hasAbstractOnly": true
+    }
+  ],
+  "qualityGates": {
+    "languageAllowlist": ["en"],
+    "licenseAllowlist": [
+      "cc-by",
+      "cc-by-sa",
+      "cc0",
+      "cc-by-nc",
+      "cc-by-nc-sa",
+      "cc-by-nd",
+      "cc-by-nc-nd"
+    ],
+    "minAbstractChars": 500,
+    "minCitedByCount": 80,
+    "minPublicationYear": 2018,
+    "maxPublicationYear": 2026,
+    "requireDoi": true,
+    "requireJournalArticle": true,
+    "requireOpenAccess": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "model:eval": "node scripts/model/evaluate-framework.mjs",
     "test:integration": "node scripts/tests/integration-smoke.mjs",
     "test:pr2-integrity": "node scripts/tests/pr2-integrity-schema-check.mjs",
-    "pipeline:complete": "node scripts/tests/complete-e2e.mjs"
+    "pipeline:complete": "node scripts/tests/complete-e2e.mjs",
+    "pipeline:q1-batch": "node scripts/papers/batch-download-and-train.mjs",
+    "papers:download-few": "node scripts/papers/download-few-open-source.mjs",
+    "test:download-few": "node scripts/tests/download-few-smoke.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.8.0",

--- a/scripts/papers/batch-download-and-train.mjs
+++ b/scripts/papers/batch-download-and-train.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cmd} ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseArgs(argv) {
+  const options = {
+    ingestConfig: "data/papers/config.q1-oa-10k.json",
+    benchmarkConfig: "data/papers/benchmark.q1-oa-10k.json",
+    trainConfig: "data/models/train.q1-oa-10k.json",
+    attempts: 3,
+    fallbackFewCount: 4,
+  };
+
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--attempts" && argv[i + 1]) {
+      const parsed = Number(argv[++i]);
+      if (Number.isFinite(parsed) && parsed >= 1) options.attempts = Math.floor(parsed);
+    } else if (arg === "--fallback-few-count" && argv[i + 1]) {
+      const parsed = Number(argv[++i]);
+      if (Number.isFinite(parsed) && parsed >= 1) options.fallbackFewCount = Math.floor(parsed);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional[0]) options.ingestConfig = positional[0];
+  if (positional[1]) options.benchmarkConfig = positional[1];
+  if (positional[2]) options.trainConfig = positional[2];
+  return options;
+}
+
+async function runIngestWithRetry(ingestConfig, attempts) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    console.log(`[batch] Ingestion attempt ${attempt}/${attempts}`);
+    try {
+      await run("node", ["scripts/papers/ingest-open-access.mjs", "--config", ingestConfig, "--output", "data/papers"]);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[batch] Ingestion attempt ${attempt} failed: ${message}`);
+      if (attempt < attempts) {
+        const waitMs = attempt * 2000;
+        console.log(`[batch] Waiting ${waitMs}ms before retry...`);
+        await sleep(waitMs);
+      }
+    }
+  }
+  return false;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  let benchmarkConfigToUse = options.benchmarkConfig;
+  let trainConfigToUse = options.trainConfig;
+
+  console.log("[batch] Step 1/4: ingest open-access papers");
+  const ingestOk = await runIngestWithRetry(options.ingestConfig, options.attempts);
+
+  if (!ingestOk) {
+    console.warn("[batch] All ingestion attempts failed. Seeding a few bundled open-source papers.");
+    await run("node", ["scripts/papers/download-few-open-source.mjs", "--count", String(options.fallbackFewCount)]);
+    benchmarkConfigToUse = "data/papers/benchmark.smoke.config.json";
+    trainConfigToUse = "data/models/train.smoke.config.json";
+  }
+
+  console.log("[batch] Step 2/4: build benchmark pairs");
+  await run("node", ["scripts/papers/build-benchmark.mjs", "--config", benchmarkConfigToUse]);
+
+  console.log("[batch] Step 3/4: train model");
+  await run("node", ["scripts/model/train-framework.mjs", "--config", trainConfigToUse]);
+
+  console.log("[batch] Step 4/4: done");
+  console.log("[batch] Completed ingestion + benchmark + training.");
+}
+
+main().catch((error) => {
+  console.error(`[batch] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/papers/download-few-open-source.mjs
+++ b/scripts/papers/download-few-open-source.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import path from "node:path";
+import process from "node:process";
+import { readJsonl, writeJson, writeJsonl } from "./lib/io.mjs";
+
+function parseArgs(argv) {
+  const options = {
+    fixturePath: "data/papers/fixtures/smoke-papers.jsonl",
+    outputRoot: "data/papers",
+    count: 4,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--fixture" && argv[i + 1]) options.fixturePath = argv[++i];
+    else if (arg === "--output" && argv[i + 1]) options.outputRoot = argv[++i];
+    else if (arg === "--count" && argv[i + 1]) {
+      const parsed = Number(argv[++i]);
+      if (Number.isFinite(parsed) && parsed > 0) options.count = Math.floor(parsed);
+    }
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const fixturePath = path.resolve(process.cwd(), options.fixturePath);
+  const outputRoot = path.resolve(process.cwd(), options.outputRoot);
+
+  const all = await readJsonl(fixturePath);
+  const selected = all.slice(0, options.count);
+
+  const currentDatasetRoot = path.join(outputRoot, "datasets", "current");
+  await writeJsonl(path.join(currentDatasetRoot, "papers.jsonl"), selected);
+
+  const manifest = {
+    pipelineVersion: "offline-few-seed-v1",
+    runId: `offline-few-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+    generatedAt: new Date().toISOString(),
+    source: "fixture",
+    stats: {
+      availableFixtureCount: all.length,
+      selectedCount: selected.length,
+    },
+    note: "Seeded current dataset from bundled open-source fixture due unavailable network source.",
+  };
+
+  await writeJson(path.join(currentDatasetRoot, "provenance.manifest.json"), manifest);
+
+  console.log(
+    JSON.stringify(
+      {
+        outputDatasetPath: path.join("data/papers", "datasets", "current", "papers.jsonl"),
+        selectedCount: selected.length,
+        sourceFixture: options.fixturePath,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(`[papers:download-few] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/tests/download-few-smoke.mjs
+++ b/scripts/tests/download-few-smoke.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+function run(cmd, args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: process.cwd(),
+      stdio: "pipe",
+      shell: process.platform === "win32",
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(`${cmd} ${args.join(" ")} failed (${code})\n${stderr}`));
+    });
+  });
+}
+
+async function main() {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "download-few-smoke-"));
+  const outputRoot = path.join(tmpRoot, "papers");
+
+  await run("node", [
+    "scripts/papers/download-few-open-source.mjs",
+    "--count",
+    "2",
+    "--output",
+    outputRoot,
+    "--fixture",
+    "data/papers/fixtures/smoke-papers.jsonl",
+  ]);
+
+  const datasetPath = path.join(outputRoot, "datasets", "current", "papers.jsonl");
+  const manifestPath = path.join(outputRoot, "datasets", "current", "provenance.manifest.json");
+
+  const datasetRaw = await fs.readFile(datasetPath, "utf8");
+  const rows = datasetRaw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (rows.length !== 2) {
+    throw new Error(`Expected 2 rows, received ${rows.length}`);
+  }
+
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  if (manifest?.stats?.selectedCount !== 2) {
+    throw new Error(`Expected manifest selectedCount=2, received ${manifest?.stats?.selectedCount}`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        datasetPath,
+        rowCount: rows.length,
+        manifestSelectedCount: manifest?.stats?.selectedCount || 0,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(`[test:download-few] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide an end-to-end batch flow to ingest open-access papers, build benchmark pairs, and train a model with a Q1 open-access configuration and a failover to a small bundled fixture when ingestion fails. 

### Description
- Add three new config files for the Q1 open-access run: `data/papers/config.q1-oa-10k.json`, `data/papers/benchmark.q1-oa-10k.json`, and `data/models/train.q1-oa-10k.json` that define ingestion, benchmark, and training parameters. 
- Implement `scripts/papers/batch-download-and-train.mjs` to orchestrate ingest + benchmark + training with retry logic and a fallback to seeded data when ingestion repeatedly fails. 
- Add `scripts/papers/download-few-open-source.mjs` to seed a small dataset from a bundled fixture and emit a provenance manifest. 
- Add a smoke test `scripts/tests/download-few-smoke.mjs` to validate the seeded dataset and update `package.json` with new npm scripts: `pipeline:q1-batch`, `papers:download-few`, and `test:download-few`.

### Testing
- Ran the new smoke test `node scripts/tests/download-few-smoke.mjs` which verifies the fixture selection and provenance manifest `selectedCount` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fdc22e2c832f93988f66dec78d78)