### PR TITLE
Add one-command Q1-ready pipeline script and npm shortcuts; document in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,31 @@ See [docs/configuration.md](./docs/configuration.md) for full details.
 3. Run humanization.
 4. Review detector/readability scores and iterate.
 
+
+### One-command legal corpus + training bootstrap (ready-made)
+
+For a complete local run (install + ingest + benchmark + train + eval) using the built-in open-access/Q1-oriented configs:
+
+```bash
+npm run pipeline:q1-ready
+```
+
+Faster reruns (skip reinstall):
+
+```bash
+npm run pipeline:q1-ready:skip-install
+```
+
+The wrapper (`scripts/papers/complete-ready-pipeline.mjs`) runs:
+
+1. `npm ci` (unless `--skip-install`)
+2. `node scripts/papers/batch-download-and-train.mjs` with Q1 OA configs
+3. `node scripts/model/evaluate-framework.mjs --manifest data/models/current/run.manifest.json`
+
+If ingestion fails due to provider/network limits, the batch stage falls back to a small bundled open-source seed set so the full pipeline can still complete.
+
+For very large corpora (for example, ~10k papers), keep PDFs/fulltext artifacts in object storage and track only configs/manifests in Git.
+
 ### Scripted benchmark/training smoke flow
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "pipeline:complete": "node scripts/tests/complete-e2e.mjs",
     "pipeline:q1-batch": "node scripts/papers/batch-download-and-train.mjs",
     "papers:download-few": "node scripts/papers/download-few-open-source.mjs",
-    "test:download-few": "node scripts/tests/download-few-smoke.mjs"
+    "test:download-few": "node scripts/tests/download-few-smoke.mjs",
+    "pipeline:q1-ready": "node scripts/papers/complete-ready-pipeline.mjs",
+    "pipeline:q1-ready:skip-install": "node scripts/papers/complete-ready-pipeline.mjs --skip-install"
   },
   "dependencies": {
     "lucide-react": "^1.8.0",

--- a/scripts/papers/complete-ready-pipeline.mjs
+++ b/scripts/papers/complete-ready-pipeline.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+function parseArgs(argv) {
+  const args = {
+    ingestConfig: "data/papers/config.q1-oa-10k.json",
+    benchmarkConfig: "data/papers/benchmark.q1-oa-10k.json",
+    trainConfig: "data/models/train.q1-oa-10k.json",
+    manifestPath: "data/models/current/run.manifest.json",
+    attempts: 3,
+    fallbackFewCount: 4,
+    skipInstall: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--ingest-config" && argv[i + 1]) args.ingestConfig = argv[++i];
+    else if (arg === "--benchmark-config" && argv[i + 1]) args.benchmarkConfig = argv[++i];
+    else if (arg === "--train-config" && argv[i + 1]) args.trainConfig = argv[++i];
+    else if (arg === "--manifest" && argv[i + 1]) args.manifestPath = argv[++i];
+    else if (arg === "--attempts" && argv[i + 1]) {
+      const value = Number(argv[++i]);
+      if (Number.isFinite(value) && value >= 1) args.attempts = Math.floor(value);
+    } else if (arg === "--fallback-few-count" && argv[i + 1]) {
+      const value = Number(argv[++i]);
+      if (Number.isFinite(value) && value >= 1) args.fallbackFewCount = Math.floor(value);
+    } else if (arg === "--skip-install") args.skipInstall = true;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+  }
+
+  return args;
+}
+
+function run(cmd, cmdArgs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, cmdArgs, { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${cmdArgs.join(" ")} failed with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    console.log(`Usage: node scripts/papers/complete-ready-pipeline.mjs [options]
+
+Options:
+  --ingest-config <path>      Ingestion config (default: data/papers/config.q1-oa-10k.json)
+  --benchmark-config <path>   Benchmark config (default: data/papers/benchmark.q1-oa-10k.json)
+  --train-config <path>       Training config (default: data/models/train.q1-oa-10k.json)
+  --manifest <path>           Eval manifest (default: data/models/current/run.manifest.json)
+  --attempts <n>              Ingestion retry count for batch script (default: 3)
+  --fallback-few-count <n>    Number of fallback seed papers (default: 4)
+  --skip-install              Skip npm ci
+`);
+    return;
+  }
+
+  if (!args.skipInstall) {
+    console.log("[ready] Step 1/3: npm ci");
+    await run("npm", ["ci"]);
+  } else {
+    console.log("[ready] Step 1/3: skipped npm ci (--skip-install)");
+  }
+
+  console.log("[ready] Step 2/3: ingestion + benchmark build + training");
+  await run("node", [
+    "scripts/papers/batch-download-and-train.mjs",
+    args.ingestConfig,
+    args.benchmarkConfig,
+    args.trainConfig,
+    "--attempts",
+    String(args.attempts),
+    "--fallback-few-count",
+    String(args.fallbackFewCount),
+  ]);
+
+  console.log("[ready] Step 3/3: evaluate trained run");
+  await run("node", ["scripts/model/evaluate-framework.mjs", "--manifest", args.manifestPath]);
+
+  console.log("[ready] Completed successfully.");
+  console.log("[ready] Tip: keep large datasets in object storage (S3/GCS/HF), commit only configs/manifests to Git.");
+}
+
+main().catch((error) => {
+  console.error(`[ready] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a single-command local pipeline to install, ingest, benchmark, train, and evaluate using the Q1 open-access configs for faster bootstrapping of a ready-made corpus and model run. 
- Support faster reruns and intermittent ingestion failures by offering a `--skip-install` option and a fallback seed set when provider/network limits prevent full ingestion.

### Description

- Add `scripts/papers/complete-ready-pipeline.mjs`, a wrapper that optionally runs `npm ci`, invokes `scripts/papers/batch-download-and-train.mjs` with configurable arguments, and runs `scripts/model/evaluate-framework.mjs` against a manifest. 
- Add `pipeline:q1-ready` and `pipeline:q1-ready:skip-install` scripts to `package.json` to expose the wrapper as a one-line npm command. 
- Update `README.md` to document the one-command pipeline usage, faster rerun variant, fallback behavior, and guidance about keeping large datasets in object storage.

### Testing

- No automated tests were added or modified for this change and existing CI/test commands remain unchanged.
- No automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8070e0700832faf0d0494d0102745)