### PR TITLE
Fix remaining risky and unsubstantiated claims in docs and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Corpus-trained humanization engine built from 10,000 Q1 open-access academic
-  papers (OpenAlex, 11 domains, 2018–2025).
+- Style-aware humanization engine calibrated from academic writing statistics
+  (OpenAlex, 11 domains, 2018–2025).
 - Style model capturing real human writing patterns: sentence length distribution
   (mean 20.5, median 20, stddev 9.4), burstiness (0.426), vocabulary diversity
   (69.4%), passive voice ratio (18.1%), transition word frequencies, and sentence

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -60,7 +60,7 @@ export default function Footer() {
           <div className="flex gap-4">
             <span className="flex items-center gap-1">🔒 No data stored on servers</span>
             <span className="flex items-center gap-1">🌍 Privacy first</span>
-            <span className="flex items-center gap-1">⚡ 100% Free</span>
+            <span className="flex items-center gap-1">⚡ Free & Open Source</span>
           </div>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>StealthHumanizer — Free AI Text Humanizer | Bypass AI Detection | Open Source</title>
+<title>StealthHumanizer — Free AI Text Humanizer | Natural AI Writing | Open Source</title>
 <meta name="description" content="Free open-source AI text humanizer. Transform AI-generated text into natural human writing with 13+ AI providers, 4 rewrite levels, 13 tones. No login required.">
 <meta name="keywords" content="AI humanizer, text humanizer, AI detector, AI text rewriter, free AI humanizer, humanize AI text, AI writing tool, make AI text human, rewrite AI text">
 <meta name="author" content="Rudra Sarker">
@@ -15,7 +15,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://rudra496.github.io/StealthHumanizer/">
 <meta property="og:title" content="StealthHumanizer — Free AI Text Humanizer">
-<meta property="og:description" content="Transform AI-generated text into natural human writing. 13+ AI providers, 4 rewrite levels, 13 tones. 100% free and open source.">
+<meta property="og:description" content="Transform AI-generated text into natural human writing. 13+ AI providers, 4 rewrite levels, 13 tones. Free and open source.">
 <meta property="og:image" content="https://rudra496.github.io/StealthHumanizer/og-image.png">
 <meta property="og:site_name" content="StealthHumanizer">
 <!-- Twitter Card -->
@@ -40,7 +40,7 @@
   "license":"https://opensource.org/licenses/MIT",
   "url":"https://rudra496.github.io/StealthHumanizer/",
   "programmingLanguage":"TypeScript",
-  "featureList":["Multi-provider AI support","13 tone presets","4 rewrite levels","Built-in AI detector","Readability analysis","No login required","100% free"]
+  "featureList":["Multi-provider AI support","13 tone presets","4 rewrite levels","Built-in AI detector","Readability analysis","No login required","Free and open source"]
 }
 </script>
 <style>
@@ -205,8 +205,8 @@ footer p{color:var(--text4);font-size:.8rem;line-height:1.8}
     <span class="hbadge">MIT License</span>
   </div>
   <div class="features">
-    <div class="feat"><div class="icon">🥷</div><h3>Ninja Mode</h3><p>5-pass auto-humanization loop targeting 100% human score</p></div>
-    <div class="feat"><div class="icon">🆓</div><h3>100% Free</h3><p>No accounts, no subscriptions, no limits — bring your API key</p></div>
+    <div class="feat"><div class="icon">🥷</div><h3>Ninja Mode</h3><p>5-pass auto-humanization loop for more natural output</p></div>
+    <div class="feat"><div class="icon">🆓</div><h3>Free &amp; Open Source</h3><p>No accounts, no subscriptions. Bring your own API key — bring your API key</p></div>
     <div class="feat"><div class="icon">🔒</div><h3>Private & Secure</h3><p>API keys stay in your browser — never sent to any server</p></div>
     <div class="feat"><div class="icon">⚡</div><h3>Ultra-Fast</h3><p>Groq & Cerebras deliver results in under 2 seconds</p></div>
     <div class="feat"><div class="icon">🌍</div><h3>16 Languages</h3><p>Humanize in English, Spanish, French, German, and more</p></div>
@@ -340,13 +340,13 @@ footer p{color:var(--text4);font-size:.8rem;line-height:1.8}
       <div style="font-size:.85rem;color:var(--text2)">
         <p>Compared to StealthWriter ($20-50/mo, 10-150 daily limit) and QuillBot ($19.95/mo, limited features), StealthHumanizer is:</p>
         <ul style="padding-left:1.2rem;margin-top:.5rem">
-          <li>✅ <strong>100% free</strong> — just use a free API key (Gemini, Groq, ZAI)</li>
+          <li>✅ <strong>Free to use</strong> — works with free API keys from Gemini, Groq, or ZAI</li>
           <li>✅ <strong>Unlimited usage</strong> — no daily caps, no word limits</li>
           <li>✅ <strong>Open source</strong> — MIT License, fully transparent</li>
           <li>✅ <strong>13+ AI providers</strong> — switch anytime</li>
           <li>✅ <strong>Private</strong> — keys never leave your browser</li>
           <li>✅ <strong>13 tone presets</strong> — more than most alternatives</li>
-          <li>✅ <strong>Ninja mode</strong> — 5-pass auto-humanization targeting 100%</li>
+          <li>✅ <strong>Ninja mode</strong> — 5-pass auto-humanization for maximum naturalness</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Continues the cleanup from #53. Replaces all remaining risky claims:

- **docs/index.html**: Title, meta tags, feature descriptions, JSON-LD — removed all "Bypass AI Detection", "100% free", "100% human score", "targeting 100%" claims
- **Footer.tsx**: "100% Free" → "Free & Open Source"
- **CHANGELOG.md**: Corpus-trained → Style-aware, removed unsubstantiated training claims