### PR TITLE
fix: preserve periods in version numbers and decimals during sentence split

### DIFF
--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -16,7 +16,12 @@ function splitIntoSentences(text: string): string[] {
     current += text[i];
     if (['.', '!', '?'].includes(text[i])) {
       const beforeMatch = text.slice(Math.max(0, i - 5), i + 1);
-      if (!abbreviations.some(abbr => beforeMatch.endsWith(abbr))) {
+      // Period inside a version/decimal/IP number (digit . alnum) is not a sentence end:
+      // "Llama 3.x", "Python 3.11", "0.5", "192.168.1.1".
+      const isVersionOrDecimal = text[i] === '.'
+        && /\d/.test(text[i - 1] || '')
+        && /[a-zA-Z0-9]/.test(text[i + 1] || '');
+      if (!isVersionOrDecimal && !abbreviations.some(abbr => beforeMatch.endsWith(abbr))) {
         if (text[i + 1] === '"' || text[i + 1] === "'") { current += text[i + 1]; i++; }
         const trimmed = current.trim();
         if (trimmed.length > 0) sentences.push(trimmed);

--- a/lib/postprocess.ts
+++ b/lib/postprocess.ts
@@ -20,8 +20,13 @@ function chance(probability: number): boolean {
 }
 
 function splitSentences(text: string): string[] {
-  // Split on sentence-ending punctuation while preserving the punctuation
-  return text.match(/[^.!?]*[.!?]+[\s]*/g)?.map(s => s.trim()).filter(s => s.length > 0) || [text.trim()];
+  // Protect periods inside version numbers, decimals, and IPs (e.g., "Llama 3.x",
+  // "Python 3.11", "0.5", "192.168.1.1") so they aren't treated as sentence boundaries.
+  const PERIOD_PLACEHOLDER = '';
+  const protectedText = text.replace(/(\d)\.(?=[a-zA-Z0-9])/g, `$1${PERIOD_PLACEHOLDER}`);
+  return protectedText.match(/[^.!?]*[.!?]+[\s]*/g)
+    ?.map(s => s.trim().replace(new RegExp(PERIOD_PLACEHOLDER, 'g'), '.'))
+    .filter(s => s.length > 0) || [text.trim()];
 }
 
 function splitParagraphs(text: string): string[] {


### PR DESCRIPTION
## Summary

Both sentence splitters (`lib/humanizer.ts` and `lib/postprocess.ts`) treated every period as a potential sentence boundary, breaking strings like `Llama 3.x` into `Llama 3.` + `x at…`, which downstream rejoin turned into `Llama 3. x at…`.

The fix skips period-as-boundary when the period sits between a digit and an alphanumeric — covering:
- Version numbers (`3.x`, `3.11`, `1.2.3`)
- Decimals (`0.5`, `$1.50`)
- IPs (`192.168.1.1`)

## Test plan

- [ ] Feed text containing `Llama 3.x` and confirm it stays intact through humanization.
- [ ] Feed text with decimals (`0.5%`, `$1.50`) and confirm no false sentence breaks.
- [ ] Feed regular sentence-ending periods and confirm they still split as before.