### PR TITLE
Fix PDF upload extraction reliability and prevent rehumanize score regressions

### DIFF
--- a/app/api/rehumanize/route.ts
+++ b/app/api/rehumanize/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
 
     const rehumanizePrompt = getRehumanizePrompt(flaggedSentences, level || 'aggressive', style || 'humanize', tone || 'conversational', customTone, purpose);
     
-    const result = await generateWithProvider(model, apiKey, rehumanizePrompt, '', { model: modelId, temperature: 1.0 });
+    const result = await generateWithProvider(model, apiKey, rehumanizePrompt, '', { model: modelId, temperature: 0.7, topP: 0.9 });
     const rehumanized = result
       .split('\n')
       .map(l => l.replace(/^\d+[\.\)]\s*/, '').trim())
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
           replacementIdx++;
         }
       }
-      const processedText = postprocess(newText, { style: (style || 'humanize') as any });
+      const processedText = postprocess(newText, { style: (style || 'humanize') as any, light: true });
       return NextResponse.json({ success: true, rehumanizedSentences: rehumanized, fullText: processedText });
     }
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,42 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
+async function extractPdfText(uint8: Uint8Array): Promise<string> {
+  const candidates = [
+    'pdfjs-dist/legacy/build/pdf.mjs',
+    'pdfjs-dist/build/pdf.mjs',
+  ];
+
+  let lastErr: unknown;
+  for (const mod of candidates) {
+    try {
+      const pdfjs = await import(mod);
+      if (pdfjs.GlobalWorkerOptions) pdfjs.GlobalWorkerOptions.workerSrc = '';
+
+      const doc = await pdfjs.getDocument({ data: uint8, useSystemFonts: true, disableWorker: true }).promise;
+      const pageTexts: string[] = [];
+
+      for (let i = 1; i <= doc.numPages; i++) {
+        const page = await doc.getPage(i);
+        const content = await page.getTextContent();
+        const lines = (content.items || [])
+          .map((item: any) => item?.str)
+          .filter((v: unknown) => typeof v === 'string' && v.trim().length > 0)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        if (lines) pageTexts.push(lines);
+      }
+
+      return pageTexts.join('\n\n').trim();
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  throw lastErr instanceof Error ? lastErr : new Error('Failed to parse PDF');
+}
+
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData();
@@ -37,24 +73,7 @@ export async function POST(request: NextRequest) {
     if (ext === 'pdf') {
       const arrayBuffer = await file.arrayBuffer();
       const uint8 = new Uint8Array(arrayBuffer);
-
-      // Use pdfjs-dist directly (pure JS, no native deps — works on Vercel serverless)
-      const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
-      // Disable worker for serverless environments
-      if (pdfjs.GlobalWorkerOptions) {
-        pdfjs.GlobalWorkerOptions.workerSrc = '';
-      }
-      const doc = await pdfjs.getDocument({ data: uint8, useSystemFonts: true }).promise;
-
-      let fullText = '';
-      for (let i = 1; i <= doc.numPages; i++) {
-        const page = await doc.getPage(i);
-        const content = await page.getTextContent();
-        const pageText = content.items
-          .map((item: any) => item.str)
-          .join(' ');
-        fullText += pageText + '\n';
-      }
+      const fullText = await extractPdfText(uint8);
 
       if (!fullText.trim()) {
         return NextResponse.json(

--- a/components/Humanizer.tsx
+++ b/components/Humanizer.tsx
@@ -348,10 +348,17 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
         });
         if (!resp.ok) break;
         const data = await resp.json();
-        currentFullText = data.fullText;
+        const candidateText = data.fullText;
+        const newDetection = detectAI(candidateText);
+        const newScore = newDetection.score;
 
-        const newDetection = detectAI(currentFullText);
-        currentScore = newDetection.score;
+        if (newScore >= currentScore) {
+          currentFullText = candidateText;
+          currentScore = newScore;
+        } else {
+          showToast('warning', `Stopped auto-refine: round ${round} would reduce score (${currentScore}% → ${newScore}%).`);
+          break;
+        }
       }
 
       const finalDetection = detectAI(currentFullText);
@@ -424,9 +431,16 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
         if (!resp.ok) break;
         const data = await resp.json();
 
-        currentFullText = data.fullText;
-        const newDetection = detectAI(currentFullText);
-        currentScore = newDetection.score;
+        const candidateText = data.fullText;
+        const newDetection = detectAI(candidateText);
+        const newScore = newDetection.score;
+        if (newScore >= currentScore) {
+          currentFullText = candidateText;
+          currentScore = newScore;
+        } else {
+          showToast('warning', `Stopped: round ${round} would reduce score (${currentScore}% → ${newScore}%).`);
+          break;
+        }
       }
 
       const finalDetection = detectAI(currentFullText);


### PR DESCRIPTION
### Motivation
- Users reported PDF uploads failing while DOCX worked, so PDF parsing needed to be made more robust for server environments. 
- Users also observed detector scores dropping after automated re-humanization passes, indicating the client blindly accepted rewrites that sometimes reduced quality. 
- The rehumanize server generation was highly stochastic and could produce unstable replacements that worsen detector scores.

### Description
- Added a dedicated `extractPdfText` helper to `app/api/upload/route.ts` that attempts multiple `pdfjs-dist` entrypoints, explicitly disables workers for server runtimes, normalizes per-page text, and returns a stable page-separated string to improve PDF parsing resilience. (modified: `app/api/upload/route.ts`)
- Tuned the rehumanize API in `app/api/rehumanize/route.ts` to use `temperature: 0.7` and `topP: 0.9`, and switched the replacement postprocess call to `light: true` to reduce aggressive/random rewrites. (modified: `app/api/rehumanize/route.ts`)
- Prevented score regressions in both auto and manual rehumanize loops in the client by evaluating each candidate rewrite with `detectAI` and only accepting it when `newScore >= currentScore`, otherwise stopping the loop and showing a warning toast. (modified: `components/Humanizer.tsx`)

### Testing
- Ran `npm run lint`; the command executed but reported repository-wide issues (3 errors and 78 warnings) and did not complete as a clean pass; the changed files were applied and committed despite the global lint output. 
- Committed changes and created a PR titled `Fix PDF upload extraction reliability and stop rehumanize score regressions` containing the three modified files: `app/api/upload/route.ts`, `app/api/rehumanize/route.ts`, and `components/Humanizer.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0340b49ee88323964ffb87f15fc95b)