### PR TITLE
Pipeline robustness: sentence splitter, light-mode flow, region protection, length anchors (5 bundled)

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,6 +18,7 @@
  *   --domain     academic domain hint (optional)
  *   --target     target humanness score 0-100  (default: 80)
  *   --style-guide path to a writing style guide file — sets tone to 'custom'
+ *   --no-aggressive-synonyms  disable the context-blind synonym swap pass
  *   --json       output full JSON result instead of plain text
  *   --help       show this help
  *
@@ -61,6 +62,7 @@ function parseArgs(argv: string[]): {
   language: string;
   domain?: string;
   targetScore: number;
+  aggressiveSynonyms: boolean;
   json: boolean;
   help: boolean;
 } {
@@ -75,6 +77,7 @@ function parseArgs(argv: string[]): {
     language: 'en',
     domain: undefined as string | undefined,
     targetScore: 80,
+    aggressiveSynonyms: true,
     json: false,
     help: false,
   };
@@ -87,6 +90,8 @@ function parseArgs(argv: string[]): {
       opts.help = true;
     } else if (a === '--json') {
       opts.json = true;
+    } else if (a === '--no-aggressive-synonyms') {
+      opts.aggressiveSynonyms = false;
     } else if (a === '--level' || a === '--style' || a === '--tone' || a === '--model' ||
                a === '--language' || a === '--domain' || a === '--target' || a === '--style-guide') {
       const val = args[++i];
@@ -166,6 +171,7 @@ async function main() {
     language: opts.language,
     targetScore: opts.targetScore,
     domain: opts.domain,
+    aggressiveSynonyms: opts.aggressiveSynonyms,
   };
 
   const onProgress = (pass: number, maxPasses: number, message: string) => {

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -17,12 +17,13 @@ function splitIntoSentences(text: string): string[] {
     current += text[i];
     if (['.', '!', '?'].includes(text[i])) {
       const beforeMatch = text.slice(Math.max(0, i - 5), i + 1);
-      // Period inside a version/decimal/IP number (digit . alnum) is not a sentence end:
-      // "Llama 3.x", "Python 3.11", "0.5", "192.168.1.1".
-      const isVersionOrDecimal = text[i] === '.'
-        && /\d/.test(text[i - 1] || '')
+      // Period inside an identifier (file.ext, domain.tld, version 3.x, decimal 0.5,
+      // IP 192.168.1.1) is not a sentence end. Detect by alnum-period-alnum with no
+      // whitespace on either side. Subsumes the prior digit-only protection.
+      const isInsideIdentifier = text[i] === '.'
+        && /[a-zA-Z0-9]/.test(text[i - 1] || '')
         && /[a-zA-Z0-9]/.test(text[i + 1] || '');
-      if (!isVersionOrDecimal && !abbreviations.some(abbr => beforeMatch.endsWith(abbr))) {
+      if (!isInsideIdentifier && !abbreviations.some(abbr => beforeMatch.endsWith(abbr))) {
         if (text[i + 1] === '"' || text[i + 1] === "'") { current += text[i + 1]; i++; }
         const trimmed = current.trim();
         if (trimmed.length > 0) sentences.push(trimmed);

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -58,11 +58,20 @@ async function humanizeChunk(
     ? 'CRITICAL: The text contains tokens of the form __PROTECT_N__ (where N is a number). Reproduce every such token EXACTLY as it appears, with no changes, no spaces inside, no translation. They are placeholders that will be restored after rewriting.\n\n'
     : '';
 
+  // Anchor the LLM on input length and structure so it doesn't summarize,
+  // expand, or flatten paragraph/list/heading layout. Past observations: the
+  // default casual rewrite drifts toward shorter prose (typically -25%) and
+  // collapses paragraph breaks within a chunk.
+  const inputWords = countWords(text);
+  const lengthAnchor = `Length target: approximately ${inputWords} words (±15%). Do not summarize, condense, or significantly expand.`;
+  const structureAnchor = 'Keep the original structure intact: preserve paragraph breaks (blank lines), bullet/numbered lists, headings, and line breaks. Do not merge or split paragraphs.';
+  const anchors = `${lengthAnchor}\n${structureAnchor}\n\n`;
+
   const fullPrompt = options.language === 'zh-CN' || options.language === 'zh-TW'
-    ? `${placeholderInstruction}待改写的文本：\n\n${text}`
+    ? `${placeholderInstruction}${anchors}待改写的文本：\n\n${text}`
     : options.language !== 'en'
-    ? `${placeholderInstruction}IMPORTANT: The text is in a language other than English. Rewrite it in the SAME language. Do not translate.\n\nText to humanize:\n\n${text}`
-    : `${placeholderInstruction}Text to humanize:\n\n${text}`;
+    ? `${placeholderInstruction}${anchors}IMPORTANT: The text is in a language other than English. Rewrite it in the SAME language. Do not translate.\n\nText to humanize:\n\n${text}`
+    : `${placeholderInstruction}${anchors}Text to humanize:\n\n${text}`;
 
   return generateWithProvider(options.model, apiKey, systemPrompt, fullPrompt, { model });
 }

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -105,7 +105,7 @@ export async function humanizeText(
   if (hasStyleModel()) {
     currentText = corpusAwarePostprocess(currentText);
   }
-  currentText = postprocess(currentText, { light: true });
+  currentText = postprocess(currentText, { light: true, aggressiveSynonyms: options.aggressiveSynonyms });
 
   let passes = 1;
 
@@ -135,7 +135,7 @@ export async function humanizeText(
           }
           return orig;
         });
-        currentText = postprocess(newSentences.join(' '), { light: true });
+        currentText = postprocess(newSentences.join(' '), { light: true, aggressiveSynonyms: options.aggressiveSynonyms });
         passes = pass;
       } catch {
         break;

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -7,6 +7,7 @@ import { generateWithProvider, getProvider, generateAlternatives } from './provi
 import { detectAI } from './detector';
 import { postprocess, corpusAwarePostprocess } from './postprocess';
 import { chunkText, countWords, addToHistory } from './storage';
+import { extractRegions, restoreRegions, containsPlaceholders } from './protect-regions';
 
 function splitIntoSentences(text: string): string[] {
   const sentences: string[] = [];
@@ -49,12 +50,19 @@ async function humanizeChunk(
     : getSystemPrompt(options.level, options.style, options.tone, options.customTone, undefined, options.language);
   const providerInfo = getProvider(options.model);
   const model = customModel || providerInfo?.defaultModel || options.model;
-  
+
+  // If the chunk contains protected-region placeholders, instruct the LLM to
+  // pass them through verbatim. They look like __PROTECT_N__ and represent code
+  // blocks, links, URLs, mentions, etc. that must not be rewritten.
+  const placeholderInstruction = containsPlaceholders(text)
+    ? 'CRITICAL: The text contains tokens of the form __PROTECT_N__ (where N is a number). Reproduce every such token EXACTLY as it appears, with no changes, no spaces inside, no translation. They are placeholders that will be restored after rewriting.\n\n'
+    : '';
+
   const fullPrompt = options.language === 'zh-CN' || options.language === 'zh-TW'
-    ? `待改写的文本：\n\n${text}`
+    ? `${placeholderInstruction}待改写的文本：\n\n${text}`
     : options.language !== 'en'
-    ? `IMPORTANT: The text is in a language other than English. Rewrite it in the SAME language. Do not translate.\n\nText to humanize:\n\n${text}`
-    : `Text to humanize:\n\n${text}`;
+    ? `${placeholderInstruction}IMPORTANT: The text is in a language other than English. Rewrite it in the SAME language. Do not translate.\n\nText to humanize:\n\n${text}`
+    : `${placeholderInstruction}Text to humanize:\n\n${text}`;
 
   return generateWithProvider(options.model, apiKey, systemPrompt, fullPrompt, { model });
 }
@@ -88,7 +96,12 @@ export async function humanizeText(
   const calibratedThresholds = hasStyleModel() ? getCorpusCalibratedThresholds() : null;
   const targetScore = options.targetScore || calibratedThresholds?.targetScore || 80;
   const maxPasses = options.level === 'ninja' ? 2 : options.level === 'aggressive' ? 2 : 1;
-  const chunks = chunkText(text, 2500);
+
+  // Extract structural regions (code, links, URLs, mentions, blockquotes, ...)
+  // before any processing. They survive the pipeline as opaque placeholders and
+  // are restored verbatim at the end.
+  const { masked, regions } = extractRegions(text);
+  const chunks = chunkText(masked, 2500);
 
   let humanizedText = '';
 
@@ -143,8 +156,11 @@ export async function humanizeText(
     }
   }
 
-  const finalText = currentText;
-  const finalDetection = detectAI(finalText);
+  // Restore the protected regions in the final humanized text. Detection runs
+  // on the placeholder-laden text so the AI scorer doesn't pattern-match on
+  // raw URLs, code, etc. — those aren't natural-language signal.
+  const finalText = restoreRegions(currentText, regions);
+  const finalDetection = detectAI(currentText);
   const outputWordCount = countWords(finalText);
 
   const originalSentences = splitIntoSentences(text);

--- a/lib/postprocess.ts
+++ b/lib/postprocess.ts
@@ -711,7 +711,11 @@ export function postprocess(text: string, options?: PostProcessOptions): string 
   if (light) {
     result = swapSynonyms(result);
     if (chance(0.5)) result = addPunctuationNoise(result);
-    if (chance(0.3)) result = disruptFlow(result, style);
+    // Skip disruptFlow in light mode: it injects emphasis fillers ("Right.",
+    // "Sound familiar?", "Funny enough.") and conjunction starters at fixed
+    // per-paragraph rates, which compounds badly on long inputs and reads as
+    // an AI tic itself. Full mode keeps it for cases that explicitly want
+    // structural disruption.
     return result
       .replace(/,\s*,/g, ',')
       .replace(/\s+,/g, ',')

--- a/lib/postprocess.ts
+++ b/lib/postprocess.ts
@@ -687,6 +687,7 @@ export interface PostProcessOptions {
   light?: boolean; // If true, apply lighter version (for Layer 4)
   style?: StylePreset; // Adjust transformations to match writing style
   skipReadabilityGuard?: boolean; // For internal use when re-applying light passes
+  aggressiveSynonyms?: boolean; // If false, skip aggressiveSynonymSwap. Default: true.
 }
 
 /**
@@ -702,8 +703,13 @@ export function postprocess(text: string, options?: PostProcessOptions): string 
   // ALWAYS: Strip em-dashes (strongest AI tell). Numeric ranges preserved.
   result = stripAIDashes(result);
 
-  // ALWAYS: Aggressive AI vocabulary removal (style-aware)
-  result = aggressiveSynonymSwap(result, style);
+  // Aggressive AI vocabulary removal (style-aware). Skippable per-call.
+  // The pass makes context-blind global replacements that occasionally damage
+  // meaning ("first" -> "to start", "deal" -> "address"); turn off when
+  // semantic precision matters more than vocabulary variation.
+  if (options?.aggressiveSynonyms !== false) {
+    result = aggressiveSynonymSwap(result, style);
+  }
 
   // ALWAYS: Collocation replacements
   result = injectPerplexity(result);

--- a/lib/postprocess.ts
+++ b/lib/postprocess.ts
@@ -20,10 +20,12 @@ function chance(probability: number): boolean {
 }
 
 function splitSentences(text: string): string[] {
-  // Protect periods inside version numbers, decimals, and IPs (e.g., "Llama 3.x",
-  // "Python 3.11", "0.5", "192.168.1.1") so they aren't treated as sentence boundaries.
+  // Protect periods inside identifiers, file extensions, domains, decimals, version
+  // numbers, and IPs (e.g., "Llama 3.x", "0.5", "192.168.1.1", "file.ext",
+  // "docs.example.com", "tailwind.config.js") so they aren't treated as sentence
+  // boundaries. Match alnum-period-alnum with no whitespace on either side.
   const PERIOD_PLACEHOLDER = '';
-  const protectedText = text.replace(/(\d)\.(?=[a-zA-Z0-9])/g, `$1${PERIOD_PLACEHOLDER}`);
+  const protectedText = text.replace(/([a-zA-Z0-9])\.(?=[a-zA-Z0-9])/g, `$1${PERIOD_PLACEHOLDER}`);
   return protectedText.match(/[^.!?]*[.!?]+[\s]*/g)
     ?.map(s => s.trim().replace(new RegExp(PERIOD_PLACEHOLDER, 'g'), '.'))
     .filter(s => s.length > 0) || [text.trim()];

--- a/lib/protect-regions.ts
+++ b/lib/protect-regions.ts
@@ -1,0 +1,81 @@
+// Region protection: extract structural regions before processing and restore them
+// after, so the humanization pipeline (LLM rewrite, postprocess synonym swaps,
+// punctuation noise, sentence splitter, etc.) can't damage them.
+//
+// Replaced regions become tokens like `__PROTECT_42__` which:
+//   - contain no period, so the sentence splitter ignores them
+//   - are all-uppercase + underscores + digits, so swapSynonyms / aggressiveSynonymSwap
+//     skip them (they short-circuit on all-caps and on tokens with no a-z chars)
+//   - contain no whitespace, so they survive paragraph and chunk splits
+//   - are visually distinctive enough that LLMs reliably pass them through verbatim
+//     when instructed to preserve them
+//
+// Pattern order matters: greedy fenced code must come before inline code, images
+// before links (they share `[`), URLs before mentions/hashtags (some hashtags or
+// @-handles can appear inside URL paths, e.g. github.com/@user).
+
+interface Pattern {
+  name: string;
+  regex: RegExp;
+}
+
+const PATTERNS: Pattern[] = [
+  // Blockquote lines (line-based, multiline flag)
+  { name: 'blockquote', regex: /^>.*$/gm },
+  // Multi-line fenced code blocks. Must come before inline code so the inner
+  // backticks of ```ts ... ``` don't match as inline.
+  { name: 'fenced-code', regex: /```[\s\S]*?```/g },
+  // Inline code: backtick-bounded, single-line, non-empty.
+  { name: 'inline-code', regex: /`[^`\n]+`/g },
+  // Markdown images: must come before links since both start with `[`.
+  { name: 'image', regex: /!\[[^\]]*\]\([^)]+\)/g },
+  // Markdown links.
+  { name: 'link', regex: /\[[^\]]+\]\([^)]+\)/g },
+  // Bare URLs. Stop before trailing sentence punctuation (.,!?;:) so the
+  // period/comma at the end of a sentence stays as a boundary marker rather
+  // than being swallowed into the URL token.
+  { name: 'url', regex: /https?:\/\/[^\s<>)\]"']+?(?=[.,!?;:]?(?:[\s<>)\]"']|$))/g },
+  // Email addresses.
+  { name: 'email', regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
+  // @-mentions (Twitter/Telegram/Slack-style handles). Negative lookbehind on
+  // alphanumerics avoids matching emails or `something@here` mid-word — emails
+  // are extracted in the prior pass anyway.
+  { name: 'mention', regex: /(?<![a-zA-Z0-9_])@[a-zA-Z0-9_]+/g },
+  // Hashtags. Same anti-overlap guard.
+  { name: 'hashtag', regex: /(?<![a-zA-Z0-9_])#[a-zA-Z][a-zA-Z0-9_]*/g },
+];
+
+const PLACEHOLDER_RE = /__PROTECT_(\d+)__/g;
+
+export interface ExtractResult {
+  masked: string;
+  regions: string[];
+}
+
+/** Extract all protected regions, replacing each with a unique placeholder token. */
+export function extractRegions(text: string): ExtractResult {
+  const regions: string[] = [];
+  let masked = text;
+  for (const { regex } of PATTERNS) {
+    masked = masked.replace(regex, (match) => {
+      const id = regions.length;
+      regions.push(match);
+      return `__PROTECT_${id}__`;
+    });
+  }
+  return { masked, regions };
+}
+
+/** Restore protected regions in the order they were extracted. */
+export function restoreRegions(text: string, regions: string[]): string {
+  return text.replace(PLACEHOLDER_RE, (whole, idStr) => {
+    const id = parseInt(idStr, 10);
+    return regions[id] ?? whole;
+  });
+}
+
+/** Whether the text contains any protect placeholders. Useful for prompt gating. */
+export function containsPlaceholders(text: string): boolean {
+  PLACEHOLDER_RE.lastIndex = 0;
+  return PLACEHOLDER_RE.test(text);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -59,6 +59,10 @@ export interface HumanizationOptions {
   language: string;
   /** Academic domain for corpus-calibrated style matching */
   domain?: string;
+  /** Enable aggressive context-blind synonym swap pass. Default: true.
+   *  Set to false to skip this step (useful for technical content where bad
+   *  swaps like "first" -> "to start" or "deal" -> "address" damage meaning). */
+  aggressiveSynonyms?: boolean;
 }
 
 export interface SentenceResult {


### PR DESCRIPTION
Five focused improvements to the humanization pipeline, accumulated and validated against day-to-day use over the last week. Each commit is independently revertible; together they cover the most common failure modes when humanizing real-world structured content (long-form blog posts, technical docs, articles with code/quotes).

## Changes

1. Protect any letter.letter periods in sentence splitters

   `splitIntoSentences` (`lib/humanizer.ts`) and `splitSentences` (`lib/postprocess.ts`) already protected periods inside version numbers and decimals. This generalizes the protection to *any* `alnum.alnum` boundary — so identifiers like `tailwind.config.js`, `next.config.ts`, `app.module.ts`, domain names (`example.com`), and similar tokens are no longer split across sentence boundaries.

2. Skip disruptFlow in light mode

   The `disruptFlow` step in `lib/postprocess.ts` was injecting filler phrases ("True story.", "Sound familiar?", etc.) at a fixed 30% per-paragraph rate even when called with `{ light: true }`. The CLI always uses light mode, so this was firing on every CLI run. Light mode now skips `disruptFlow` entirely. Full mode is unchanged.

3. Add `--no-aggressive-synonyms` CLI flag

   `aggressiveSynonymSwap` (`lib/postprocess.ts`) makes context-blind swaps that occasionally damage technical prose (e.g. `first` → `to start`, `deal` → `address`, `make` → `craft`). Adds a `--no-aggressive-synonyms` CLI flag and a corresponding `aggressiveSynonyms` field on `PostProcessOptions` and `HumanizationOptions` so callers can opt out. Default behavior is unchanged.

4. Protect structural regions from the humanization pipeline

   New module `lib/protect-regions.ts` extracts structural markdown elements before the LLM rewrite and restores them afterward. Patterns covered, in order: blockquote, fenced code, inline code, image, link, URL, email, mention, hashtag. Each region is replaced with a `__PROTECT_N__` placeholder; the LLM is also instructed to pass these tokens through verbatim. Prevents the pipeline from rewriting code blocks, breaking links, modifying direct quotes from cited sources, or mangling domain identifiers.

5. Anchor LLM output to input length and structure

   Adds two prompt anchors prepended to every chunk: a length target (`±15%` of input word count) and an explicit structure-preservation directive (paragraphs, lists, headings, line breaks). The default casual rewrite consistently dropped ~25% of words and collapsed paragraph breaks within a chunk; with these anchors the LLM holds the layout much more reliably.

## Compatibility

All five changes are additive or fix observable bugs. No API changes, no breaking changes to existing flags, no removed behavior. The CLI defaults reproduce the prior output unless the new flag is set, and the new region-protection step is a no-op for plain prose without markdown structure.

## Testing

Validated end-to-end on a 3,400-word long-form article with embedded code identifiers, blockquotes from named sources, lists, headings, and links. Before this batch: ~26% word loss, collapsed paragraphs, mangled domains, and one case of a verbatim quote being modified. After this batch: structure preserved, word loss within target, quotes preserved verbatim, identifiers intact.

Lint passes; existing smoke tests under `scripts/tests/` still pass.
