### PR TITLE
feat(cli): add stealthhumanizer CLI for humanize, detect, and provider listing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,21 @@
 # StealthHumanizer Environment Variables
 
+# CLI/provider API keys
+# Set whichever provider you want to use with `npm run cli -- humanize`.
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GROQ_API_KEY=
+MISTRAL_API_KEY=
+COHERE_API_KEY=
+TOGETHER_API_KEY=
+OPENROUTER_API_KEY=
+CEREBRAS_API_KEY=
+DEEPINFRA_API_KEY=
+HUGGINGFACE_API_KEY=
+CLOUDFLARE_API_KEY=
+ZAI_API_KEY=
+
 # GPTZero API Key (optional)
 # Used for AI detection scoring in the Detector tab
 # Get your key at https://gptzero.me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: CLI regression
+        run: npm run test:cli
+
       - name: PR2 analysis smoke
         run: npm run papers:analyze -- --config data/papers/analysis.smoke.config.json --run-id ci-pr2-smoke
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -107,6 +107,42 @@ Or use it live at [stealthhumanizer.vercel.app](https://stealthhumanizer.vercel.
 
 ---
 
+## CLI
+
+StealthHumanizer now ships an initial command-line interface for local
+humanization and detector checks.
+
+```bash
+# Run without installing a global binary
+npm run cli -- detect --text "Furthermore, it is important to note that..."
+
+# Humanize from stdin with the Gemini provider
+export GEMINI_API_KEY="your-key"
+echo "Draft text..." | npm run cli -- humanize --model gemini --level medium
+
+# Read and write files
+npm run cli -- humanize --input draft.txt --output humanized.txt --style academic
+```
+
+The package exposes both `stealthhumanizer` and `stealth-humanize` binaries
+when built or linked:
+
+```bash
+npm run cli:build
+npm link
+stealthhumanizer providers
+```
+
+Useful commands:
+
+- `humanize` - runs the full multi-pass rewriting pipeline
+- `detect` - scores text with the built-in AI-signal detector, no API key needed
+- `providers` - lists provider ids, default models, and API key environment variables
+
+Run `npm run cli -- --help` for the full option list.
+
+---
+
 ## Groq (Free) Setup & Demo Walkthrough
 
 This walkthrough is specifically for the **Groq (Free)** provider flow.
@@ -236,7 +272,7 @@ Read [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
 ## Roadmap
 
 - [ ] Browser extension (Chrome/Firefox)
-- [ ] CLI tool (`npx stealthhumanizer`)
+- [x] CLI tool (`stealthhumanizer`, initial local/package binary)
 - [ ] Fine-tuned local models for offline use
 - [ ] Real detector benchmarking dashboard
 - [ ] API service layer for programmatic access

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Useful commands:
 
 Run `npm run cli -- --help` for the full option list.
 
+Run `npm run test:cli` to build the packaged CLI entry point and execute the
+CLI regression suite.
+
 ---
 
 ## Groq (Free) Setup & Demo Walkthrough

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,199 +1,633 @@
-#!/usr/bin/env tsx
-/**
- * StealthHumanizer CLI — wraps the full 4-layer TypeScript humanization pipeline.
- *
- * Usage:
- *   echo "Your text" | npx tsx bin/cli.ts [options]
- *   npx tsx bin/cli.ts [options] "Your text here"
- *
- * Options:
- *   --level      light | medium | aggressive | ninja  (default: medium)
- *   --style      humanize | academic | casual | professional | creative | technical  (default: casual)
- *   --tone       conversational | academic-formal | academic-casual | journalistic |
- *                creative-writing | professional | technical | persuasive |
- *                storytelling | humorous | emotional | analytical | custom  (default: conversational)
- *   --model      gemini | openai | claude | groq | mistral | cohere | together |
- *                openrouter | cerebras | deepinfra | huggingface | cloudflare | zai  (default: openai)
- *   --language   BCP-47 language code  (default: en)
- *   --domain     academic domain hint (optional)
- *   --target     target humanness score 0-100  (default: 80)
- *   --style-guide path to a writing style guide file — sets tone to 'custom'
- *   --no-aggressive-synonyms  disable the context-blind synonym swap pass
- *   --json       output full JSON result instead of plain text
- *   --help       show this help
- *
- * API keys are read from environment variables:
- *   GROQ_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY,
- *   MISTRAL_API_KEY, COHERE_API_KEY, TOGETHER_API_KEY, OPENROUTER_API_KEY,
- *   CEREBRAS_API_KEY, DEEPINFRA_API_KEY, HUGGINGFACE_API_KEY,
- *   CLOUDFLARE_API_KEY, ZAI_API_KEY
- */
-
+#!/usr/bin/env node
 import 'dotenv/config';
-import { readFileSync } from 'fs';
-import { humanizeText } from '../lib/humanizer';
-import type { HumanizationOptions, ModelProvider, RewriteLevel, StylePreset, TonePreset } from '../lib/types';
 
-// ── env var map ──────────────────────────────────────────────────────────────
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { detectAI, getDetailedDetectionReport } from '../lib/detector';
+import { humanizeText } from '../lib/humanizer';
+import { getAvailableProvider, getProvider, PROVIDERS } from '../lib/providers';
+import type { DetectionResult, HumanizationOptions, ModelProvider, RewriteLevel, StylePreset, TonePreset } from '../lib/types';
+
+type Command = 'humanize' | 'detect' | 'providers';
+
+interface ParsedCli {
+  command: Command;
+  commandExplicit: boolean;
+  flags: Map<string, string | boolean>;
+  positionals: string[];
+}
+
+const COMMANDS: readonly Command[] = ['humanize', 'detect', 'providers'];
+const LEVELS: readonly RewriteLevel[] = ['light', 'medium', 'aggressive', 'ninja'];
+const STYLES: readonly StylePreset[] = ['humanize', 'academic', 'casual', 'professional', 'creative', 'technical'];
+const TONES: readonly TonePreset[] = [
+  'academic-formal',
+  'academic-casual',
+  'journalistic',
+  'creative-writing',
+  'conversational',
+  'professional',
+  'technical',
+  'persuasive',
+  'storytelling',
+  'humorous',
+  'emotional',
+  'analytical',
+  'custom',
+];
+const PROVIDER_IDS = PROVIDERS.map((provider) => provider.id);
+
 const API_KEY_ENV: Record<ModelProvider, string> = {
-  groq:        'GROQ_API_KEY',
-  openai:      'OPENAI_API_KEY',
-  claude:      'ANTHROPIC_API_KEY',
-  gemini:      'GEMINI_API_KEY',
-  mistral:     'MISTRAL_API_KEY',
-  cohere:      'COHERE_API_KEY',
-  together:    'TOGETHER_API_KEY',
-  openrouter:  'OPENROUTER_API_KEY',
-  cerebras:    'CEREBRAS_API_KEY',
-  deepinfra:   'DEEPINFRA_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  claude: 'ANTHROPIC_API_KEY',
+  groq: 'GROQ_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+  cohere: 'COHERE_API_KEY',
+  together: 'TOGETHER_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  cerebras: 'CEREBRAS_API_KEY',
+  deepinfra: 'DEEPINFRA_API_KEY',
   huggingface: 'HUGGINGFACE_API_KEY',
-  cloudflare:  'CLOUDFLARE_API_KEY',
-  zai:         'ZAI_API_KEY',
+  cloudflare: 'CLOUDFLARE_API_KEY',
+  zai: 'ZAI_API_KEY',
 };
 
-// ── arg parser ───────────────────────────────────────────────────────────────
-function parseArgs(argv: string[]): {
-  text: string | null;
-  level: RewriteLevel;
-  style: StylePreset;
-  tone: TonePreset;
-  customTone?: string;
-  model: ModelProvider;
-  language: string;
-  domain?: string;
-  targetScore: number;
-  aggressiveSynonyms: boolean;
-  json: boolean;
-  help: boolean;
-} {
-  const args = argv.slice(2);
-  const opts = {
-    text: null as string | null,
-    level: 'medium' as RewriteLevel,
-    style: 'casual' as StylePreset,
-    tone: 'conversational' as TonePreset,
-    customTone: undefined as string | undefined,
-    model: 'openai' as ModelProvider,
-    language: 'en',
-    domain: undefined as string | undefined,
-    targetScore: 80,
-    aggressiveSynonyms: true,
-    json: false,
-    help: false,
-  };
+const VALUE_FLAGS = new Set([
+  'api-key',
+  'api-key-env',
+  'domain',
+  'input',
+  'language',
+  'level',
+  'model',
+  'output',
+  'style',
+  'style-guide',
+  'target',
+  'text',
+  'tone',
+]);
 
-  const positional: string[] = [];
+const BOOLEAN_FLAGS = new Set([
+  'help',
+  'json',
+  'no-aggressive-synonyms',
+  'quiet',
+  'report',
+  'sentences',
+  'version',
+]);
 
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
-    if (a === '--help' || a === '-h') {
-      opts.help = true;
-    } else if (a === '--json') {
-      opts.json = true;
-    } else if (a === '--no-aggressive-synonyms') {
-      opts.aggressiveSynonyms = false;
-    } else if (a === '--level' || a === '--style' || a === '--tone' || a === '--model' ||
-               a === '--language' || a === '--domain' || a === '--target' || a === '--style-guide') {
-      const val = args[++i];
-      if (!val) { process.stderr.write(`Missing value for ${a}\n`); process.exit(1); }
-      if (a === '--level')       opts.level = val as RewriteLevel;
-      if (a === '--style')       opts.style = val as StylePreset;
-      if (a === '--tone')        opts.tone = val as TonePreset;
-      if (a === '--model')       opts.model = val as ModelProvider;
-      if (a === '--language')    opts.language = val;
-      if (a === '--domain')      opts.domain = val;
-      if (a === '--target')      opts.targetScore = parseInt(val, 10);
-      if (a === '--style-guide') {
-        opts.customTone = readFileSync(val, 'utf8');
-        opts.tone = 'custom';
+const FLAG_ALIASES: Record<string, string> = {
+  h: 'help',
+  i: 'input',
+  j: 'json',
+  m: 'model',
+  o: 'output',
+  p: 'model',
+  q: 'quiet',
+  s: 'sentences',
+  v: 'version',
+};
+
+class CliError extends Error {
+  constructor(message: string, readonly showUsage = false) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+function isCommand(value: string | undefined): value is Command {
+  return value !== undefined && COMMANDS.includes(value as Command);
+}
+
+function normalizeFlagName(name: string): string {
+  if (name === 'provider') return 'model';
+  if (name === 'target-score') return 'target';
+  return name;
+}
+
+function parseCli(argv: string[]): ParsedCli {
+  const tokens = argv.slice(2);
+  const flags = new Map<string, string | boolean>();
+  const positionals: string[] = [];
+  let command: Command = 'humanize';
+  let commandExplicit = false;
+
+  if (tokens[0] === 'help') {
+    flags.set('help', true);
+    if (isCommand(tokens[1])) {
+      command = tokens[1];
+      commandExplicit = true;
+    }
+    return { command, commandExplicit, flags, positionals };
+  }
+
+  if (isCommand(tokens[0])) {
+    command = tokens.shift() as Command;
+    commandExplicit = true;
+  }
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+
+    if (token === '--') {
+      positionals.push(...tokens.slice(i + 1));
+      break;
+    }
+
+    if (token.startsWith('--')) {
+      const equalsIndex = token.indexOf('=');
+      const rawName = equalsIndex === -1 ? token.slice(2) : token.slice(2, equalsIndex);
+      const name = normalizeFlagName(rawName);
+      const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+
+      if (BOOLEAN_FLAGS.has(name)) {
+        flags.set(name, inlineValue === undefined ? true : inlineValue !== 'false');
+        continue;
       }
-    } else if (!a.startsWith('--')) {
-      positional.push(a);
+
+      if (!VALUE_FLAGS.has(name)) {
+        throw new CliError(`Unknown option: --${rawName}`, true);
+      }
+
+      const value = inlineValue ?? tokens[++i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new CliError(`Missing value for --${rawName}`);
+      }
+      flags.set(name, value);
+      continue;
+    }
+
+    if (token.startsWith('-') && token !== '-') {
+      const alias = token.slice(1);
+      const name = FLAG_ALIASES[alias];
+      if (!name) {
+        throw new CliError(`Unknown option: -${alias}`, true);
+      }
+
+      if (BOOLEAN_FLAGS.has(name)) {
+        flags.set(name, true);
+        continue;
+      }
+
+      const value = tokens[++i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new CliError(`Missing value for -${alias}`);
+      }
+      flags.set(name, value);
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { command, commandExplicit, flags, positionals };
+}
+
+function flagString(parsed: ParsedCli, name: string): string | undefined {
+  const value = parsed.flags.get(name);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function flagBoolean(parsed: ParsedCli, name: string): boolean {
+  return parsed.flags.get(name) === true;
+}
+
+function validateChoice<T extends string>(value: string, allowed: readonly T[], label: string): T {
+  if (!allowed.includes(value as T)) {
+    throw new CliError(`Invalid ${label}: ${value}. Expected one of: ${allowed.join(', ')}`);
+  }
+  return value as T;
+}
+
+function parseTargetScore(value: string | undefined): number {
+  if (value === undefined) return 80;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    throw new CliError(`Invalid --target: ${value}. Expected a number from 0 to 100.`);
+  }
+  return Math.round(parsed);
+}
+
+function readPackageVersion(): string {
+  const candidates = [
+    path.resolve(__dirname, '../package.json'),
+    path.resolve(__dirname, '../../package.json'),
+    path.resolve(process.cwd(), 'package.json'),
+  ];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as { name?: string; version?: string };
+      if (parsed.name === 'stealthhumanizer' && parsed.version) return parsed.version;
+    } catch {
+      // Ignore malformed package metadata and fall through to the next candidate.
     }
   }
 
-  if (positional.length > 0) opts.text = positional.join(' ');
-  return opts;
+  return 'unknown';
 }
 
-// ── read stdin ───────────────────────────────────────────────────────────────
+function readTextFile(filePath: string): string {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Input file not found: ${filePath}`);
+  }
+  return readFileSync(filePath, 'utf8');
+}
+
 async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { data += chunk; });
-    process.stdin.on('end', () => resolve(data.trim()));
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
 }
 
-// ── main ─────────────────────────────────────────────────────────────────────
-async function main() {
-  const opts = parseArgs(process.argv);
+async function resolveInputText(parsed: ParsedCli): Promise<string> {
+  const explicitText = flagString(parsed, 'text');
+  if (explicitText !== undefined) return explicitText;
 
-  if (opts.help) {
-    const helpText = (await import('fs')).readFileSync(new URL(import.meta.url).pathname, 'utf8')
-      .split('\n').slice(1, 25).map(l => l.replace(/^\s*\*\s?/, '')).join('\n');
-    process.stdout.write(helpText + '\n');
-    process.exit(0);
+  const inputPath = flagString(parsed, 'input');
+  if (inputPath !== undefined) {
+    return inputPath === '-' ? readStdin() : readTextFile(inputPath);
   }
 
-  // Resolve text
-  const isStdinTTY = process.stdin.isTTY;
-  let text = opts.text;
-  if (!text) {
-    if (isStdinTTY) {
-      process.stderr.write('Error: provide text as argument or via stdin\n');
-      process.exit(1);
-    }
-    text = await readStdin();
+  if (parsed.positionals.length > 0) {
+    return parsed.positionals.join(' ');
   }
 
-  if (!text) {
-    process.stderr.write('Error: empty input\n');
-    process.exit(1);
+  if (process.stdin.isTTY !== true) {
+    return readStdin();
   }
 
-  // Resolve API key
-  const envVar = API_KEY_ENV[opts.model];
-  const apiKey = process.env[envVar] || '';
+  throw new CliError('Provide text as an argument, with --text, with --input, or via stdin.', true);
+}
+
+function requireNonEmptyText(text: string): string {
+  const normalized = text.replace(/^\uFEFF/, '').trim();
+  if (!normalized) {
+    throw new CliError('Input text is empty.');
+  }
+  return normalized;
+}
+
+function resolveProvider(parsed: ParsedCli): ModelProvider {
+  const requestedProvider = flagString(parsed, 'model');
+  if (requestedProvider !== undefined) {
+    return validateChoice(requestedProvider, PROVIDER_IDS, '--model');
+  }
+
+  const envKeys: Record<string, string | undefined> = {};
+  for (const provider of PROVIDERS) {
+    envKeys[provider.id] = process.env[API_KEY_ENV[provider.id]];
+  }
+
+  return getAvailableProvider(envKeys) ?? 'gemini';
+}
+
+function resolveApiKey(parsed: ParsedCli, provider: ModelProvider): string {
+  const explicitApiKey = flagString(parsed, 'api-key');
+  if (explicitApiKey) return explicitApiKey;
+
+  const envName = flagString(parsed, 'api-key-env') ?? API_KEY_ENV[provider];
+  const apiKey = process.env[envName];
   if (!apiKey) {
-    process.stderr.write(`Error: ${envVar} is not set (required for --model ${opts.model})\n`);
-    process.exit(1);
+    throw new CliError(`Missing API key for ${provider}. Set ${envName} or pass --api-key.`);
+  }
+  return apiKey;
+}
+
+function resolveHumanizationOptions(parsed: ParsedCli, provider: ModelProvider): HumanizationOptions {
+  const styleGuidePath = flagString(parsed, 'style-guide');
+  const customTone = styleGuidePath ? readTextFile(styleGuidePath) : undefined;
+
+  return {
+    level: validateChoice(flagString(parsed, 'level') ?? 'medium', LEVELS, '--level'),
+    style: validateChoice(flagString(parsed, 'style') ?? 'casual', STYLES, '--style'),
+    tone: customTone
+      ? 'custom'
+      : validateChoice(flagString(parsed, 'tone') ?? 'conversational', TONES, '--tone'),
+    customTone,
+    model: provider,
+    targetScore: parseTargetScore(flagString(parsed, 'target')),
+    language: flagString(parsed, 'language') ?? 'en',
+    domain: flagString(parsed, 'domain'),
+    aggressiveSynonyms: !flagBoolean(parsed, 'no-aggressive-synonyms'),
+  };
+}
+
+function writeOutput(parsed: ParsedCli, content: string): void {
+  const output = content.endsWith('\n') ? content : `${content}\n`;
+  const outputPath = flagString(parsed, 'output');
+  if (outputPath) {
+    writeFileSync(outputPath, output, 'utf8');
+    return;
+  }
+  process.stdout.write(output);
+}
+
+function formatSentence(sentence: string): string {
+  return sentence.length > 120 ? `${sentence.slice(0, 117)}...` : sentence;
+}
+
+function humanizeMetricName(metric: string): string {
+  return metric
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function formatDetectionSummary(result: DetectionResult, includeSentences: boolean): string {
+  const lines = [
+    `Score: ${result.score}% human (${result.overallVerdict})`,
+    `Confidence: ${result.confidenceInterval.lower}-${result.confidenceInterval.upper}`,
+    `Readability: grade ${result.readability.fleschKincaidGrade}, ${result.readability.readingTimeMinutes} min read`,
+    '',
+    'Metrics:',
+  ];
+
+  for (const [metric, value] of Object.entries(result.analysis)) {
+    lines.push(`  ${humanizeMetricName(metric)}: ${value}`);
   }
 
-  const options: HumanizationOptions = {
-    level: opts.level,
-    style: opts.style,
-    tone: opts.tone,
-    customTone: opts.customTone,
-    model: opts.model,
-    language: opts.language,
-    targetScore: opts.targetScore,
-    domain: opts.domain,
-    aggressiveSynonyms: opts.aggressiveSynonyms,
-  };
+  const issueSentences = result.sentences
+    .filter((sentence) => sentence.issues.length > 0)
+    .slice(0, 5);
 
-  const onProgress = (pass: number, maxPasses: number, message: string) => {
-    process.stderr.write(`[${pass}/${maxPasses}] ${message}\n`);
-  };
-
-  try {
-    const result = await humanizeText(text, options, apiKey, onProgress);
-
-    if (opts.json) {
-      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-    } else {
-      process.stdout.write(result.fullText + '\n');
-      process.stderr.write(
-        `\n✓ Done — score: ${result.finalScore}% human | passes: ${result.passes} | ` +
-        `words: ${result.wordCount.input}→${result.wordCount.output} | model: ${result.modelName}\n`
-      );
+  if (issueSentences.length > 0) {
+    lines.push('', 'Top sentence issues:');
+    for (const sentence of issueSentences) {
+      lines.push(`  [${sentence.classification} ${sentence.score}%] ${formatSentence(sentence.text)}`);
+      lines.push(`    ${sentence.issues.join('; ')}`);
     }
-  } catch (err) {
-    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
+  }
+
+  if (includeSentences && result.sentences.length > 0) {
+    lines.push('', 'Sentences:');
+    for (const sentence of result.sentences) {
+      lines.push(`  [${sentence.classification} ${sentence.score}%] ${sentence.text}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatDetailedReport(text: string): string {
+  const report = getDetailedDetectionReport(text);
+  const lines = [
+    `Score: ${report.overallScore}% human (${report.verdict})`,
+    `Confidence: ${report.confidenceInterval.lower}-${report.confidenceInterval.upper}`,
+    '',
+    'Most AI-like sentences:',
+  ];
+
+  for (const sentence of report.topAiSentences) {
+    lines.push(`  [${sentence.score}%] ${sentence.text}`);
+    if (sentence.issues.length > 0) lines.push(`    ${sentence.issues.join('; ')}`);
+  }
+
+  if (report.foundAiPhrases.length > 0) {
+    lines.push('', 'Detected AI phrases:');
+    for (const phrase of report.foundAiPhrases.slice(0, 10)) {
+      lines.push(`  ${phrase}`);
+    }
+  }
+
+  if (report.recommendations.length > 0) {
+    lines.push('', 'Recommendations:');
+    for (const recommendation of report.recommendations) {
+      lines.push(`  ${recommendation}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatProvidersJson(): string {
+  const payload = PROVIDERS.map((provider) => ({
+    id: provider.id,
+    name: provider.name,
+    free: provider.free,
+    defaultModel: provider.defaultModel,
+    models: provider.models,
+    env: API_KEY_ENV[provider.id],
+    getApiKeyUrl: provider.getApiKeyUrl,
+    docsUrl: provider.docsUrl,
+  }));
+  return JSON.stringify(payload, null, 2);
+}
+
+function pad(value: string, width: number): string {
+  return value + ' '.repeat(Math.max(0, width - value.length));
+}
+
+function formatProvidersTable(): string {
+  const rows = PROVIDERS.map((provider) => ({
+    provider: provider.id,
+    free: provider.free ? 'yes' : 'no',
+    env: API_KEY_ENV[provider.id],
+    defaultModel: provider.defaultModel,
+    name: provider.name,
+  }));
+
+  const headers = {
+    provider: 'Provider',
+    free: 'Free',
+    env: 'Env var',
+    defaultModel: 'Default model',
+    name: 'Name',
+  };
+
+  const widths = {
+    provider: Math.max(headers.provider.length, ...rows.map((row) => row.provider.length)),
+    free: Math.max(headers.free.length, ...rows.map((row) => row.free.length)),
+    env: Math.max(headers.env.length, ...rows.map((row) => row.env.length)),
+    defaultModel: Math.max(headers.defaultModel.length, ...rows.map((row) => row.defaultModel.length)),
+  };
+
+  const lines = [
+    `${pad(headers.provider, widths.provider)}  ${pad(headers.free, widths.free)}  ${pad(headers.env, widths.env)}  ${pad(headers.defaultModel, widths.defaultModel)}  ${headers.name}`,
+    `${'-'.repeat(widths.provider)}  ${'-'.repeat(widths.free)}  ${'-'.repeat(widths.env)}  ${'-'.repeat(widths.defaultModel)}  ----`,
+  ];
+
+  for (const row of rows) {
+    lines.push(
+      `${pad(row.provider, widths.provider)}  ${pad(row.free, widths.free)}  ${pad(row.env, widths.env)}  ${pad(row.defaultModel, widths.defaultModel)}  ${row.name}`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function mainHelp(): string {
+  return `StealthHumanizer CLI
+
+Usage:
+  stealthhumanizer humanize [options] [text]
+  stealthhumanizer detect [options] [text]
+  stealthhumanizer providers [--json]
+  stealthhumanizer [options] [text]
+
+Commands:
+  humanize    Rewrite text with the full humanization pipeline (default)
+  detect      Score text with the built-in AI-signal detector
+  providers   List supported providers and API key environment variables
+
+Examples:
+  stealthhumanizer detect --text "This paper explores the multifaceted impacts of..."
+  echo "Draft text" | stealthhumanizer humanize --model gemini --level aggressive
+  stealthhumanizer humanize --input draft.txt --output humanized.txt --style academic
+  stealthhumanizer providers
+
+Run "stealthhumanizer help humanize" for command options.`;
+}
+
+function humanizeHelp(): string {
+  return `Usage:
+  stealthhumanizer humanize [options] [text]
+  stealthhumanizer [options] [text]
+
+Input:
+  --text <text>             Text to process
+  -i, --input <path|->      Read text from a file or stdin
+
+Output:
+  -o, --output <path>       Write output to a file
+  -j, --json                Write the full JSON result
+  -q, --quiet               Hide progress and summary lines
+
+Humanization options:
+  -m, --model <provider>    Provider id (default: first configured env key, then gemini)
+  --level <level>           light, medium, aggressive, ninja (default: medium)
+  --style <style>           humanize, academic, casual, professional, creative, technical
+  --tone <tone>             conversational, academic-formal, journalistic, technical, etc.
+  --language <code>         BCP-47 language code (default: en)
+  --domain <name>           Optional academic domain hint
+  --target <0-100>          Target human score (default: 80)
+  --style-guide <path>      File with custom writing guidance; sets tone to custom
+  --no-aggressive-synonyms  Disable context-blind synonym swaps
+
+API keys:
+  --api-key <key>           Pass an API key directly
+  --api-key-env <name>      Read the API key from a custom environment variable
+
+Run "stealthhumanizer providers" to see provider ids and default env vars.`;
+}
+
+function detectHelp(): string {
+  return `Usage:
+  stealthhumanizer detect [options] [text]
+
+Input:
+  --text <text>             Text to score
+  -i, --input <path|->      Read text from a file or stdin
+
+Output:
+  -o, --output <path>       Write output to a file
+  -j, --json                Write JSON instead of a text summary
+  -s, --sentences           Include every sentence in text output
+  --report                  Include detailed issue and recommendation output`;
+}
+
+function providersHelp(): string {
+  return `Usage:
+  stealthhumanizer providers [--json]
+
+Lists supported provider ids, default models, and API key environment variables.`;
+}
+
+function helpFor(command: Command): string {
+  if (command === 'humanize') return humanizeHelp();
+  if (command === 'detect') return detectHelp();
+  return providersHelp();
+}
+
+async function runHumanize(parsed: ParsedCli): Promise<void> {
+  const text = requireNonEmptyText(await resolveInputText(parsed));
+  const provider = resolveProvider(parsed);
+  const providerInfo = getProvider(provider);
+  const apiKey = resolveApiKey(parsed, provider);
+  const options = resolveHumanizationOptions(parsed, provider);
+  const quiet = flagBoolean(parsed, 'quiet');
+
+  const result = await humanizeText(text, options, apiKey, (pass, maxPasses, message) => {
+    if (!quiet) process.stderr.write(`[${pass}/${maxPasses}] ${message}\n`);
+  });
+
+  if (flagBoolean(parsed, 'json')) {
+    writeOutput(parsed, JSON.stringify(result, null, 2));
+    return;
+  }
+
+  writeOutput(parsed, result.fullText);
+
+  if (!quiet) {
+    const outputPath = flagString(parsed, 'output');
+    const destination = outputPath ? ` | output: ${outputPath}` : '';
+    process.stderr.write(
+      `\nDone: ${result.finalScore}% human | passes: ${result.passes} | words: ${result.wordCount.input} -> ${result.wordCount.output} | provider: ${providerInfo?.name ?? provider}${destination}\n`,
+    );
   }
 }
 
-main();
+async function runDetect(parsed: ParsedCli): Promise<void> {
+  const text = requireNonEmptyText(await resolveInputText(parsed));
+
+  if (flagBoolean(parsed, 'json')) {
+    const payload = flagBoolean(parsed, 'report') ? getDetailedDetectionReport(text) : detectAI(text);
+    writeOutput(parsed, JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const result = flagBoolean(parsed, 'report')
+    ? formatDetailedReport(text)
+    : formatDetectionSummary(detectAI(text), flagBoolean(parsed, 'sentences'));
+  writeOutput(parsed, result);
+}
+
+function runProviders(parsed: ParsedCli): void {
+  writeOutput(parsed, flagBoolean(parsed, 'json') ? formatProvidersJson() : formatProvidersTable());
+}
+
+async function main(): Promise<void> {
+  const parsed = parseCli(process.argv);
+
+  if (flagBoolean(parsed, 'version')) {
+    process.stdout.write(`${readPackageVersion()}\n`);
+    return;
+  }
+
+  if (flagBoolean(parsed, 'help')) {
+    process.stdout.write(`${parsed.commandExplicit ? helpFor(parsed.command) : mainHelp()}\n`);
+    return;
+  }
+
+  if (parsed.command === 'detect') {
+    await runDetect(parsed);
+    return;
+  }
+
+  if (parsed.command === 'providers') {
+    runProviders(parsed);
+    return;
+  }
+
+  await runHumanize(parsed);
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof CliError) {
+    process.stderr.write(`Error: ${error.message}\n`);
+    if (error.showUsage) process.stderr.write('\nRun "stealthhumanizer --help" for usage.\n');
+  } else {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+  process.exitCode = 1;
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,9 @@ const nextTypeScript = require('eslint-config-next/typescript'); // eslint-disab
 
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
+  {
+    ignores: ['dist/**'],
+  },
   ...nextConfig,
   ...nextTypeScript,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "jspdf": "^4.2.1",
         "lucide-react": "^1.16.0",
         "mammoth": "^1.12.0",
@@ -19,7 +20,8 @@
         "recharts": "^3.8.1"
       },
       "bin": {
-        "stealth-humanize": "bin/cli.ts"
+        "stealth-humanize": "dist/bin/cli.js",
+        "stealthhumanizer": "dist/bin/cli.js"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -27,7 +29,6 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.5.0",
-        "dotenv": "^17.4.2",
         "eslint": "^9.0.0",
         "eslint-config-next": "^16.2.6",
         "postcss": "^8.5.15",
@@ -83,6 +84,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2550,6 +2552,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2622,6 +2625,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3104,6 +3108,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3527,6 +3532,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4049,7 +4055,6 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4369,6 +4374,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4509,6 +4515,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6995,6 +7002,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -7085,6 +7093,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7094,6 +7103,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7105,13 +7115,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7179,7 +7191,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7957,6 +7970,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8125,6 +8139,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8469,6 +8484,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,25 @@
   "name": "stealthhumanizer",
   "version": "2.1.0",
   "private": true,
+  "files": [
+    "dist",
+    "data/models/corpus-style-model.json",
+    "public/corpus-style-model.json",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20"
   },
   "bin": {
-    "stealth-humanize": "bin/cli.ts"
+    "stealthhumanizer": "dist/bin/cli.js",
+    "stealth-humanize": "dist/bin/cli.js"
   },
   "scripts": {
     "cli": "tsx bin/cli.ts",
     "cli:build": "tsc --project tsconfig.cli.json",
+    "cli:smoke": "npm run cli -- --help && npm run cli -- detect --text \"Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.\"",
+    "prepack": "npm run cli:build",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -31,6 +41,7 @@
     "pipeline:q1-ready:skip-install": "node scripts/papers/complete-ready-pipeline.mjs --skip-install"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "jspdf": "^4.2.1",
     "lucide-react": "^1.16.0",
     "mammoth": "^1.12.0",
@@ -46,7 +57,6 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.5.0",
-    "dotenv": "^17.4.2",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.2.6",
     "postcss": "^8.5.15",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cli": "tsx bin/cli.ts",
     "cli:build": "tsc --project tsconfig.cli.json",
     "cli:smoke": "npm run cli -- --help && npm run cli -- detect --text \"Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.\"",
+    "test:cli": "npm run cli:build && node scripts/tests/cli.test.mjs",
     "prepack": "npm run cli:build",
     "dev": "next dev",
     "build": "next build",

--- a/scripts/tests/cli.test.mjs
+++ b/scripts/tests/cli.test.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const cliPath = path.join(repoRoot, "dist/bin/cli.js");
+const mockFetchPath = path.join(repoRoot, "scripts/tests/fixtures/mock-cli-fetch.mjs");
+const providerEnvVars = [
+  "GEMINI_API_KEY",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "COHERE_API_KEY",
+  "TOGETHER_API_KEY",
+  "OPENROUTER_API_KEY",
+  "CEREBRAS_API_KEY",
+  "DEEPINFRA_API_KEY",
+  "HUGGINGFACE_API_KEY",
+  "CLOUDFLARE_API_KEY",
+  "ZAI_API_KEY",
+];
+
+let tmpRoot;
+
+before(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "stealthhumanizer-cli-"));
+});
+
+after(async () => {
+  if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+function testEnv(extra = {}) {
+  const env = { ...process.env };
+  for (const key of providerEnvVars) delete env[key];
+
+  Object.assign(env, extra);
+  return env;
+}
+
+function withMockFetch(extra = {}) {
+  const mockImport = `--import=${pathToFileURL(mockFetchPath).href}`;
+  const priorNodeOptions = extra.NODE_OPTIONS ?? process.env.NODE_OPTIONS ?? "";
+  return testEnv({
+    ...extra,
+    NODE_OPTIONS: [priorNodeOptions, mockImport].filter(Boolean).join(" "),
+  });
+}
+
+function runCli(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: repoRoot,
+      env: options.env ?? testEnv(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (options.input !== undefined) child.stdin.end(options.input);
+    else child.stdin.end();
+  });
+}
+
+function assertSuccess(result) {
+  assert.equal(result.code, 0, result.stderr);
+}
+
+function assertFailure(result) {
+  assert.notEqual(result.code, 0, "Expected command to fail.");
+}
+
+function parseJsonOutput(result) {
+  assertSuccess(result);
+  assert.equal(result.stderr, "");
+  return JSON.parse(result.stdout);
+}
+
+describe("StealthHumanizer CLI", () => {
+  test("prints the package version", async () => {
+    const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8"));
+    const result = await runCli(["--version"]);
+
+    assertSuccess(result);
+    assert.equal(result.stdout.trim(), packageJson.version);
+    assert.equal(result.stderr, "");
+  });
+
+  test("prints top-level and command-specific help", async () => {
+    const topLevel = await runCli(["--help"]);
+    assertSuccess(topLevel);
+    assert.match(topLevel.stdout, /StealthHumanizer CLI/);
+    assert.match(topLevel.stdout, /humanize\s+Rewrite text/);
+    assert.match(topLevel.stdout, /detect\s+Score text/);
+    assert.match(topLevel.stdout, /providers\s+List supported providers/);
+
+    const detectHelp = await runCli(["help", "detect"]);
+    assertSuccess(detectHelp);
+    assert.match(detectHelp.stdout, /stealthhumanizer detect/);
+    assert.match(detectHelp.stdout, /--report/);
+    assert.doesNotMatch(detectHelp.stdout, /Humanization options/);
+  });
+
+  test("lists providers as a readable table", async () => {
+    const result = await runCli(["providers"]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Provider\s+Free\s+Env var\s+Default model\s+Name/);
+    assert.match(result.stdout, /gemini\s+yes\s+GEMINI_API_KEY\s+gemini-1\.5-flash/);
+    assert.match(result.stdout, /openai\s+no\s+OPENAI_API_KEY\s+gpt-4o/);
+    assert.equal(result.stderr, "");
+  });
+
+  test("lists providers as structured JSON", async () => {
+    const providers = parseJsonOutput(await runCli(["providers", "--json"]));
+    const gemini = providers.find((provider) => provider.id === "gemini");
+    const openai = providers.find((provider) => provider.id === "openai");
+
+    assert.ok(Array.isArray(providers));
+    assert.ok(providers.length >= 10);
+    assert.equal(gemini.env, "GEMINI_API_KEY");
+    assert.equal(gemini.free, true);
+    assert.equal(gemini.defaultModel, "gemini-1.5-flash");
+    assert.equal(openai.free, false);
+    assert.equal(Object.hasOwn(gemini, "getApiKeyUrl"), true);
+  });
+
+  test("scores text from --text with readable detector output", async () => {
+    const result = await runCli([
+      "detect",
+      "--text",
+      "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    ]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Score: \d+% human \((human|mixed|ai)\)/);
+    assert.match(result.stdout, /Metrics:/);
+    assert.match(result.stdout, /AI phrase: "it is important to note"/);
+    assert.equal(result.stderr, "");
+  });
+
+  test("scores stdin as detector JSON", async () => {
+    const result = await runCli(["detect", "--json"], {
+      input: "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    });
+    const payload = parseJsonOutput(result);
+
+    assert.equal(typeof payload.score, "number");
+    assert.equal(payload.overallVerdict, "mixed");
+    assert.equal(payload.sentences.length, 1);
+    assert.ok(payload.sentences[0].issues.some((issue) => issue.includes("it is important to note")));
+    assert.equal(typeof payload.readability.fleschKincaidGrade, "number");
+  });
+
+  test("writes detector output to a file and can include every sentence", async () => {
+    const inputPath = path.join(tmpRoot, "draft.txt");
+    const outputPath = path.join(tmpRoot, "detect-report.txt");
+    await fs.writeFile(
+      inputPath,
+      "This paper explores the multifaceted impacts of automation. Furthermore, it is important to note that adoption can optimize workflows.",
+    );
+
+    const result = await runCli(["detect", "--input", inputPath, "--output", outputPath, "--sentences"]);
+    const output = await fs.readFile(outputPath, "utf8");
+
+    assertSuccess(result);
+    assert.equal(result.stdout, "");
+    assert.match(output, /Sentences:/);
+    assert.match(output, /This paper explores the multifaceted impacts of automation/);
+    assert.match(output, /Furthermore, it is important to note/);
+  });
+
+  test("prints detailed detector report output", async () => {
+    const result = await runCli([
+      "detect",
+      "--report",
+      "--text",
+      "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    ]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Most AI-like sentences:/);
+    assert.match(result.stdout, /Detected AI phrases:/);
+    assert.match(result.stdout, /Recommendations:/);
+    assert.match(result.stdout, /Focus on rewriting the lowest-scoring sentence/);
+  });
+
+  test("fails cleanly for unknown options and invalid choices", async () => {
+    const unknownOption = await runCli(["detect", "--bogus"]);
+    assertFailure(unknownOption);
+    assert.match(unknownOption.stderr, /Unknown option: --bogus/);
+    assert.match(unknownOption.stderr, /Run "stealthhumanizer --help"/);
+
+    const invalidProvider = await runCli([
+      "humanize",
+      "--text",
+      "hello",
+      "--api-key",
+      "fake-key",
+      "--model",
+      "notaprovider",
+    ]);
+    assertFailure(invalidProvider);
+    assert.match(invalidProvider.stderr, /Invalid --model: notaprovider/);
+    assert.doesNotMatch(invalidProvider.stderr, /API key/);
+
+    const invalidTarget = await runCli([
+      "humanize",
+      "--text",
+      "hello",
+      "--model",
+      "gemini",
+      "--api-key",
+      "fake-key",
+      "--target",
+      "150",
+    ]);
+    assertFailure(invalidTarget);
+    assert.match(invalidTarget.stderr, /Invalid --target: 150/);
+  });
+
+  test("fails before network calls when humanize has no API key", async () => {
+    const result = await runCli(["humanize", "--text", "hello", "--model", "gemini"]);
+
+    assertFailure(result);
+    assert.match(result.stderr, /Missing API key for gemini/);
+    assert.match(result.stderr, /GEMINI_API_KEY/);
+    assert.equal(result.stdout, "");
+  });
+
+  test("humanizes text with mocked provider fetch and writes plain output", async () => {
+    const outputPath = path.join(tmpRoot, "humanized.txt");
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "gemini",
+        "--api-key",
+        "fake-key",
+        "--output",
+        outputPath,
+        "--quiet",
+      ],
+      { env: withMockFetch() },
+    );
+    const output = await fs.readFile(outputPath, "utf8");
+
+    assertSuccess(result);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+    assert.match(output, /rewritten paragraph/i);
+    assert.match(output, /meaning intact/i);
+  });
+
+  test("humanizes text as JSON and preserves option mapping", async () => {
+    const styleGuidePath = path.join(tmpRoot, "style-guide.txt");
+    await fs.writeFile(styleGuidePath, "Use plain, direct language with short paragraphs.");
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Please rewrite this while preserving the link https://example.com.",
+        "--model",
+        "gemini",
+        "--api-key-env",
+        "CUSTOM_GEMINI_KEY",
+        "--json",
+        "--quiet",
+        "--style",
+        "academic",
+        "--level",
+        "light",
+        "--language",
+        "en-US",
+        "--domain",
+        "Computer Science",
+        "--target",
+        "77",
+        "--style-guide",
+        styleGuidePath,
+        "--no-aggressive-synonyms",
+      ],
+      { env: withMockFetch({ CUSTOM_GEMINI_KEY: "fake-key" }) },
+    );
+    const payload = parseJsonOutput(result);
+
+    assert.match(payload.fullText, /rewritten paragraph/i);
+    assert.match(payload.fullText, /https:\/\/example\.com/);
+    assert.equal(payload.model, "gemini");
+    assert.equal(payload.options.style, "academic");
+    assert.equal(payload.options.level, "light");
+    assert.equal(payload.options.language, "en-US");
+    assert.equal(payload.options.domain, "Computer Science");
+    assert.equal(payload.options.targetScore, 77);
+    assert.equal(payload.options.tone, "custom");
+    assert.equal(payload.options.customTone, "Use plain, direct language with short paragraphs.");
+    assert.equal(payload.options.aggressiveSynonyms, false);
+  });
+});

--- a/scripts/tests/fixtures/mock-cli-fetch.mjs
+++ b/scripts/tests/fixtures/mock-cli-fetch.mjs
@@ -1,0 +1,39 @@
+const jsonResponse = (body, init = {}) =>
+  new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+
+globalThis.fetch = async (url, init = {}) => {
+  const href = String(url);
+
+  if (href.includes("corpus-style-model.json")) {
+    return new Response("not found", { status: 404 });
+  }
+
+  if (href.includes("generativelanguage.googleapis.com")) {
+    const body = typeof init.body === "string" ? JSON.parse(init.body) : {};
+    const prompt = body?.contents?.[0]?.parts?.[0]?.text || "";
+
+    return jsonResponse({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: prompt.includes("__PROTECT_")
+                  ? "This rewritten paragraph keeps __PROTECT_0__ intact. It reads naturally now."
+                  : "This rewritten paragraph keeps its meaning intact. It reads naturally now.",
+              },
+            ],
+          },
+        },
+      ],
+    });
+  }
+
+  return jsonResponse(
+    { error: { message: `Unexpected mocked fetch URL: ${href}` } },
+    { status: 500 },
+  );
+};

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": false,
+    "noEmitOnError": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["bin/cli.ts"]
+}


### PR DESCRIPTION
Closes #103

## Summary

Adds a first-class command-line interface so terminal-first workflows, CI pipelines, and quick one-off rewrites don't have to drop into a Node script. The CLI wraps the existing `lib/humanizer` and `lib/detector` modules — no pipeline logic was duplicated or rewritten.

The package now exposes two binaries (`stealthhumanizer` and `stealth-humanize`) via `package.json`'s `bin` field, with a `prepack` step that compiles `bin/cli.ts` to `dist/bin/cli.js` so `npm install -g` / `npx` work once the package is published.

## What's in the CLI

Three subcommands, with `humanize` as the default if none is given:

- **`humanize`** — full multi-pass rewriting pipeline. Reads from `--text`, `-i/--input <path|->`, positional args, or stdin. Writes to stdout or `-o/--output`. Supports `--model`, `--level`, `--style`, `--tone`, `--language`, `--domain`, `--target`, `--style-guide
<path>`, `--no-aggressive-synonyms`, `--json`, `--quiet`.
- **`detect`** — scores text with the built-in AI-signal detector. No API key required. Supports `--report` for detailed output and `--sentences` for per-sentence breakdown.
- **`providers`** — lists all 13 supported LLM providers, whether they're free, their default model, and the env var each one reads from. Available as a table or `--json`.

Standard niceties: `--help` (top-level and per-command via `help <command>`), `--version` reading from `package.json`, exit code 1 on any error, distinct usage vs runtime error messages, short aliases (`-i`, `-o`, `-m`, `-j`, `-q`, `-s`, `-v`, `-h`).

API keys are picked up from provider-specific env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, etc.) or passed via `--api-key` / `--api-key-env`. The CLI also auto-selects a provider based on which env keys are present, falling back to `gemini`.

## Examples

```bash
echo "Some AI-generated text." | stealthhumanizer
stealthhumanizer -i input.txt -o output.txt
stealthhumanizer "Quick inline text to humanize"
stealthhumanizer detect --text "Furthermore, it is important to note..."
stealthhumanizer providers --json

Tests

Added scripts/tests/cli.test.mjs (12 tests, all passing) covering:
- --version and --help (top-level + subcommand)
- Provider listing in both table and JSON forms
- Detector output via --text, stdin, file I/O, JSON, and --report
- Unknown flags, invalid --model, and out-of-range --target all fail with clear messages
- Missing API key fails before any network call
- Full humanize round-trip through a mock-fetch fixture (scripts/tests/fixtures/mock-cli-fetch.mjs) that's injected via NODE_OPTIONS=--import=..., so the real pipeline runs without hitting a live provider

Wired into CI via .github/workflows/ci.yml. Runs locally with npm run test:cli.

Test plan

- [ ] npm run cli:build succeeds
- [ ] npm run test:cli is green (12/12)
- [ ] npm run cli -- --help shows all three subcommands
- [ ] npm run cli -- detect --text "Furthermore, it is important to note that this is significant." returns a score
- [ ] npm run cli -- providers shows the 13-provider table
- [ ] With GEMINI_API_KEY set: echo "draft text" | npm run cli -- humanize --model gemini --quiet returns rewritten text on stdout
- [ ] npm run cli -- --bogus exits 1 with Unknown option: --bogus on stderr

Scope

- New: bin/cli.ts, tsconfig.cli.json, scripts/tests/cli.test.mjs, scripts/tests/fixtures/mock-cli-fetch.mjs
- Changed: package.json (bin entries, scripts, prepack, files allowlist, moved dotenv to dependencies), README.md (CLI section + roadmap), .github/workflows/ci.yml, .env.example, .gitignore, eslint.config.js
- Non-breaking: no existing module signatures changed