### PR TITLE
feat(cli): Claude Code & Codex local CLI-runner providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,21 @@
 # StealthHumanizer Environment Variables
 
+# CLI/provider API keys
+# Set whichever provider you want to use with `npm run cli -- humanize`.
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GROQ_API_KEY=
+MISTRAL_API_KEY=
+COHERE_API_KEY=
+TOGETHER_API_KEY=
+OPENROUTER_API_KEY=
+CEREBRAS_API_KEY=
+DEEPINFRA_API_KEY=
+HUGGINGFACE_API_KEY=
+CLOUDFLARE_API_KEY=
+ZAI_API_KEY=
+
 # GPTZero API Key (optional)
 # Used for AI detection scoring in the Detector tab
 # Get your key at https://gptzero.me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: CLI regression
+        run: npm run test:cli
+
       - name: PR2 analysis smoke
         run: npm run papers:analyze -- --config data/papers/analysis.smoke.config.json --run-id ci-pr2-smoke
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ Useful commands:
 
 Run `npm run cli -- --help` for the full option list.
 
+### Local CLI-runner providers (no API key)
+
+Two providers run a local CLI you already have logged in, as a subprocess,
+instead of calling an HTTP API. They use the binary's own auth, so no API key
+is required:
+
+```bash
+# Uses your local Claude Code login
+stealthhumanizer humanize --model claude-code -i draft.txt
+
+# Uses your local OpenAI Codex login
+echo "Draft text..." | stealthhumanizer humanize --model codex
+```
+
+- `--model claude-code` spawns your local `claude` CLI (Claude Code)
+- `--model codex` spawns your local `codex` CLI (OpenAI Codex)
+- Point at a non-default binary with `STEALTHHUMANIZER_CLAUDE_CODE_BIN` or
+  `STEALTHHUMANIZER_CODEX_BIN`
+- CLI-only: these are skipped by auto-selection and are not available in the
+  browser or serverless runtimes (they spawn a subprocess). The web API rejects
+  them (including in model chains) so a browser user can't make a self-hosted
+  server spawn its logged-in CLI.
+
+**Security note — untrusted input.** The text being humanized is treated as
+untrusted (it can contain prompt-injection). The runners are confined so an
+injected instruction can't make the agent act:
+
+- `claude-code` runs with `--tools ""`, which fully disables all tools — it
+  cannot read/write files or run commands. Preferred for untrusted input.
+- `codex` has no "disable all tools" switch, so it is confined as tightly as
+  the platform allows: `--sandbox read-only` (no writes/network), an isolated
+  empty working directory, and no inherited environment. A determined injection
+  could still read absolute paths via a read-only command, so prefer
+  `claude-code` when the input is fully untrusted.
+
 Run `npm run test:cli` to build the packaged CLI entry point and execute the
 CLI regression suite.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,42 @@ Or use it live at [stealthhumanizer.vercel.app](https://stealthhumanizer.vercel.
 
 ---
 
+## CLI
+
+StealthHumanizer now ships an initial command-line interface for local
+humanization and detector checks.
+
+```bash
+# Run without installing a global binary
+npm run cli -- detect --text "Furthermore, it is important to note that..."
+
+# Humanize from stdin with the Gemini provider
+export GEMINI_API_KEY="your-key"
+echo "Draft text..." | npm run cli -- humanize --model gemini --level medium
+
+# Read and write files
+npm run cli -- humanize --input draft.txt --output humanized.txt --style academic
+```
+
+The package exposes both `stealthhumanizer` and `stealth-humanize` binaries
+when built or linked:
+
+```bash
+npm run cli:build
+npm link
+stealthhumanizer providers
+```
+
+Useful commands:
+
+- `humanize` - runs the full multi-pass rewriting pipeline
+- `detect` - scores text with the built-in AI-signal detector, no API key needed
+- `providers` - lists provider ids, default models, and API key environment variables
+
+Run `npm run cli -- --help` for the full option list.
+
+---
+
 ## Groq (Free) Setup & Demo Walkthrough
 
 This walkthrough is specifically for the **Groq (Free)** provider flow.
@@ -236,7 +272,7 @@ Read [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
 ## Roadmap
 
 - [ ] Browser extension (Chrome/Firefox)
-- [ ] CLI tool (`npx stealthhumanizer`)
+- [x] CLI tool (`stealthhumanizer`, initial local/package binary)
 - [ ] Fine-tuned local models for offline use
 - [ ] Real detector benchmarking dashboard
 - [ ] API service layer for programmatic access

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Useful commands:
 
 Run `npm run cli -- --help` for the full option list.
 
+Run `npm run test:cli` to build the packaged CLI entry point and execute the
+CLI regression suite.
+
 ---
 
 ## Groq (Free) Setup & Demo Walkthrough

--- a/app/api/alternative/route.ts
+++ b/app/api/alternative/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { generateWithProvider, generateAlternatives } from '@/lib/providers';
+import { generateAlternatives } from '@/lib/server/providers-runtime';
+import { isCliOnlyProvider } from '@/lib/providers';
 import { getSystemPrompt } from '@/lib/prompts';
 
 export async function POST(request: NextRequest) {
   try {
     const { original, current, level, style, tone, customTone, model, apiKey } = await request.json();
     if (!original || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing fields' }, { status: 400 });
+    if (isCliOnlyProvider(model)) return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
 
     const systemPrompt = getSystemPrompt(level, style, tone, customTone);
     const alternatives = await generateAlternatives(model, apiKey, original, current, systemPrompt, 3);

--- a/app/api/grammar/route.ts
+++ b/app/api/grammar/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ModelProvider } from '@/lib/types';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { GRAMMAR_CHECK_SYSTEM_PROMPT } from '@/lib/prompts';
 
 export async function POST(request: NextRequest) {
   try {
     const { text, model, apiKey } = await request.json();
     if (!text || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    if (isCliOnlyProvider(model)) return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
 
     const providerInfo = getProvider(model);
     const modelId = providerInfo?.defaultModel || model;

--- a/app/api/humanize-batch/route.ts
+++ b/app/api/humanize-batch/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { detectAI } from '@/lib/detector';
 import { postprocess } from '@/lib/postprocess';
 import { getSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
-import { generateWithProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
+import { isCliOnlyProvider } from '@/lib/providers';
 import { RewriteLevel } from '@/lib/types';
 import { asyncMapConcurrent } from '@/lib/batch';
 import { checkRateLimit } from '@/lib/rate-limit';
@@ -27,6 +28,9 @@ export async function POST(request: NextRequest) {
 
     if (!model || !apiKey) {
       return NextResponse.json({ success: false, error: 'Missing required fields: model and apiKey' }, { status: 400 });
+    }
+    if (isCliOnlyProvider(model)) {
+      return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     }
 
     if (!Array.isArray(texts) || texts.length === 0) {

--- a/app/api/humanize/route.ts
+++ b/app/api/humanize/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { RewriteLevel, StylePreset, TonePreset, ModelProvider } from '@/lib/types';
-import { getSystemPrompt, getRehumanizePrompt, getSelfCheckPrompt, getFixPrompt, getCorpusAwareSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { RewriteLevel, StylePreset, ModelProvider } from '@/lib/types';
+import { getSystemPrompt, getSelfCheckPrompt, getCorpusAwareSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { detectAI } from '@/lib/detector';
 import { postprocess, corpusAwarePostprocess } from '@/lib/postprocess';
 import { loadStyleModelAsync, loadStyleModel, hasStyleModel } from '@/lib/style-model';
@@ -76,6 +77,12 @@ export async function POST(request: NextRequest) {
     } = await request.json();
 
     if (!text || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    // Reject CLI-only runners on the primary model AND anywhere in the chain —
+    // chainModels flows through lib/chain into the CLI-capable runtime, so an
+    // unguarded chain entry would otherwise spawn the server's local CLI.
+    const cliOnlyRequested = [model, ...(Array.isArray(chainModelIds) ? chainModelIds : [])]
+      .find((id) => isCliOnlyProvider(id as ModelProvider));
+    if (cliOnlyRequested) return NextResponse.json({ success: false, error: `Provider "${cliOnlyRequested}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     if (countWords(text) > 10000) return NextResponse.json({ success: false, error: 'Exceeds 10,000 word limit' }, { status: 400 });
     if (Array.isArray(batchTexts) && batchTexts.length > MAX_BATCH_SIZE) {
       return NextResponse.json({ success: false, error: `Batch size exceeds limit (${MAX_BATCH_SIZE}).` }, { status: 400 });

--- a/app/api/rehumanize/route.ts
+++ b/app/api/rehumanize/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { RewriteLevel, StylePreset, TonePreset, ModelProvider } from '@/lib/types';
 import { getRehumanizePrompt } from '@/lib/prompts';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { postprocess } from '@/lib/postprocess';
 
 export async function POST(request: NextRequest) {
@@ -9,6 +9,9 @@ export async function POST(request: NextRequest) {
     const { flaggedSentences, level, style, tone, customTone, model, apiKey, fullText, purpose } = await request.json();
     if (!flaggedSentences?.length || !model || !apiKey) {
       return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    }
+    if (isCliOnlyProvider(model)) {
+      return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     }
 
     const providerInfo = getProvider(model);

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,199 +1,633 @@
-#!/usr/bin/env tsx
-/**
- * StealthHumanizer CLI — wraps the full 4-layer TypeScript humanization pipeline.
- *
- * Usage:
- *   echo "Your text" | npx tsx bin/cli.ts [options]
- *   npx tsx bin/cli.ts [options] "Your text here"
- *
- * Options:
- *   --level      light | medium | aggressive | ninja  (default: medium)
- *   --style      humanize | academic | casual | professional | creative | technical  (default: casual)
- *   --tone       conversational | academic-formal | academic-casual | journalistic |
- *                creative-writing | professional | technical | persuasive |
- *                storytelling | humorous | emotional | analytical | custom  (default: conversational)
- *   --model      gemini | openai | claude | groq | mistral | cohere | together |
- *                openrouter | cerebras | deepinfra | huggingface | cloudflare | zai  (default: openai)
- *   --language   BCP-47 language code  (default: en)
- *   --domain     academic domain hint (optional)
- *   --target     target humanness score 0-100  (default: 80)
- *   --style-guide path to a writing style guide file — sets tone to 'custom'
- *   --no-aggressive-synonyms  disable the context-blind synonym swap pass
- *   --json       output full JSON result instead of plain text
- *   --help       show this help
- *
- * API keys are read from environment variables:
- *   GROQ_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY,
- *   MISTRAL_API_KEY, COHERE_API_KEY, TOGETHER_API_KEY, OPENROUTER_API_KEY,
- *   CEREBRAS_API_KEY, DEEPINFRA_API_KEY, HUGGINGFACE_API_KEY,
- *   CLOUDFLARE_API_KEY, ZAI_API_KEY
- */
-
+#!/usr/bin/env node
 import 'dotenv/config';
-import { readFileSync } from 'fs';
-import { humanizeText } from '../lib/humanizer';
-import type { HumanizationOptions, ModelProvider, RewriteLevel, StylePreset, TonePreset } from '../lib/types';
 
-// ── env var map ──────────────────────────────────────────────────────────────
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { detectAI, getDetailedDetectionReport } from '../lib/detector';
+import { humanizeText } from '../lib/humanizer';
+import { getAvailableProvider, getProvider, PROVIDERS } from '../lib/providers';
+import type { DetectionResult, HumanizationOptions, ModelProvider, RewriteLevel, StylePreset, TonePreset } from '../lib/types';
+
+type Command = 'humanize' | 'detect' | 'providers';
+
+interface ParsedCli {
+  command: Command;
+  commandExplicit: boolean;
+  flags: Map<string, string | boolean>;
+  positionals: string[];
+}
+
+const COMMANDS: readonly Command[] = ['humanize', 'detect', 'providers'];
+const LEVELS: readonly RewriteLevel[] = ['light', 'medium', 'aggressive', 'ninja'];
+const STYLES: readonly StylePreset[] = ['humanize', 'academic', 'casual', 'professional', 'creative', 'technical'];
+const TONES: readonly TonePreset[] = [
+  'academic-formal',
+  'academic-casual',
+  'journalistic',
+  'creative-writing',
+  'conversational',
+  'professional',
+  'technical',
+  'persuasive',
+  'storytelling',
+  'humorous',
+  'emotional',
+  'analytical',
+  'custom',
+];
+const PROVIDER_IDS = PROVIDERS.map((provider) => provider.id);
+
 const API_KEY_ENV: Record<ModelProvider, string> = {
-  groq:        'GROQ_API_KEY',
-  openai:      'OPENAI_API_KEY',
-  claude:      'ANTHROPIC_API_KEY',
-  gemini:      'GEMINI_API_KEY',
-  mistral:     'MISTRAL_API_KEY',
-  cohere:      'COHERE_API_KEY',
-  together:    'TOGETHER_API_KEY',
-  openrouter:  'OPENROUTER_API_KEY',
-  cerebras:    'CEREBRAS_API_KEY',
-  deepinfra:   'DEEPINFRA_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  claude: 'ANTHROPIC_API_KEY',
+  groq: 'GROQ_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+  cohere: 'COHERE_API_KEY',
+  together: 'TOGETHER_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  cerebras: 'CEREBRAS_API_KEY',
+  deepinfra: 'DEEPINFRA_API_KEY',
   huggingface: 'HUGGINGFACE_API_KEY',
-  cloudflare:  'CLOUDFLARE_API_KEY',
-  zai:         'ZAI_API_KEY',
+  cloudflare: 'CLOUDFLARE_API_KEY',
+  zai: 'ZAI_API_KEY',
 };
 
-// ── arg parser ───────────────────────────────────────────────────────────────
-function parseArgs(argv: string[]): {
-  text: string | null;
-  level: RewriteLevel;
-  style: StylePreset;
-  tone: TonePreset;
-  customTone?: string;
-  model: ModelProvider;
-  language: string;
-  domain?: string;
-  targetScore: number;
-  aggressiveSynonyms: boolean;
-  json: boolean;
-  help: boolean;
-} {
-  const args = argv.slice(2);
-  const opts = {
-    text: null as string | null,
-    level: 'medium' as RewriteLevel,
-    style: 'casual' as StylePreset,
-    tone: 'conversational' as TonePreset,
-    customTone: undefined as string | undefined,
-    model: 'openai' as ModelProvider,
-    language: 'en',
-    domain: undefined as string | undefined,
-    targetScore: 80,
-    aggressiveSynonyms: true,
-    json: false,
-    help: false,
-  };
+const VALUE_FLAGS = new Set([
+  'api-key',
+  'api-key-env',
+  'domain',
+  'input',
+  'language',
+  'level',
+  'model',
+  'output',
+  'style',
+  'style-guide',
+  'target',
+  'text',
+  'tone',
+]);
 
-  const positional: string[] = [];
+const BOOLEAN_FLAGS = new Set([
+  'help',
+  'json',
+  'no-aggressive-synonyms',
+  'quiet',
+  'report',
+  'sentences',
+  'version',
+]);
 
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
-    if (a === '--help' || a === '-h') {
-      opts.help = true;
-    } else if (a === '--json') {
-      opts.json = true;
-    } else if (a === '--no-aggressive-synonyms') {
-      opts.aggressiveSynonyms = false;
-    } else if (a === '--level' || a === '--style' || a === '--tone' || a === '--model' ||
-               a === '--language' || a === '--domain' || a === '--target' || a === '--style-guide') {
-      const val = args[++i];
-      if (!val) { process.stderr.write(`Missing value for ${a}\n`); process.exit(1); }
-      if (a === '--level')       opts.level = val as RewriteLevel;
-      if (a === '--style')       opts.style = val as StylePreset;
-      if (a === '--tone')        opts.tone = val as TonePreset;
-      if (a === '--model')       opts.model = val as ModelProvider;
-      if (a === '--language')    opts.language = val;
-      if (a === '--domain')      opts.domain = val;
-      if (a === '--target')      opts.targetScore = parseInt(val, 10);
-      if (a === '--style-guide') {
-        opts.customTone = readFileSync(val, 'utf8');
-        opts.tone = 'custom';
+const FLAG_ALIASES: Record<string, string> = {
+  h: 'help',
+  i: 'input',
+  j: 'json',
+  m: 'model',
+  o: 'output',
+  p: 'model',
+  q: 'quiet',
+  s: 'sentences',
+  v: 'version',
+};
+
+class CliError extends Error {
+  constructor(message: string, readonly showUsage = false) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+function isCommand(value: string | undefined): value is Command {
+  return value !== undefined && COMMANDS.includes(value as Command);
+}
+
+function normalizeFlagName(name: string): string {
+  if (name === 'provider') return 'model';
+  if (name === 'target-score') return 'target';
+  return name;
+}
+
+function parseCli(argv: string[]): ParsedCli {
+  const tokens = argv.slice(2);
+  const flags = new Map<string, string | boolean>();
+  const positionals: string[] = [];
+  let command: Command = 'humanize';
+  let commandExplicit = false;
+
+  if (tokens[0] === 'help') {
+    flags.set('help', true);
+    if (isCommand(tokens[1])) {
+      command = tokens[1];
+      commandExplicit = true;
+    }
+    return { command, commandExplicit, flags, positionals };
+  }
+
+  if (isCommand(tokens[0])) {
+    command = tokens.shift() as Command;
+    commandExplicit = true;
+  }
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+
+    if (token === '--') {
+      positionals.push(...tokens.slice(i + 1));
+      break;
+    }
+
+    if (token.startsWith('--')) {
+      const equalsIndex = token.indexOf('=');
+      const rawName = equalsIndex === -1 ? token.slice(2) : token.slice(2, equalsIndex);
+      const name = normalizeFlagName(rawName);
+      const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+
+      if (BOOLEAN_FLAGS.has(name)) {
+        flags.set(name, inlineValue === undefined ? true : inlineValue !== 'false');
+        continue;
       }
-    } else if (!a.startsWith('--')) {
-      positional.push(a);
+
+      if (!VALUE_FLAGS.has(name)) {
+        throw new CliError(`Unknown option: --${rawName}`, true);
+      }
+
+      const value = inlineValue ?? tokens[++i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new CliError(`Missing value for --${rawName}`);
+      }
+      flags.set(name, value);
+      continue;
+    }
+
+    if (token.startsWith('-') && token !== '-') {
+      const alias = token.slice(1);
+      const name = FLAG_ALIASES[alias];
+      if (!name) {
+        throw new CliError(`Unknown option: -${alias}`, true);
+      }
+
+      if (BOOLEAN_FLAGS.has(name)) {
+        flags.set(name, true);
+        continue;
+      }
+
+      const value = tokens[++i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new CliError(`Missing value for -${alias}`);
+      }
+      flags.set(name, value);
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { command, commandExplicit, flags, positionals };
+}
+
+function flagString(parsed: ParsedCli, name: string): string | undefined {
+  const value = parsed.flags.get(name);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function flagBoolean(parsed: ParsedCli, name: string): boolean {
+  return parsed.flags.get(name) === true;
+}
+
+function validateChoice<T extends string>(value: string, allowed: readonly T[], label: string): T {
+  if (!allowed.includes(value as T)) {
+    throw new CliError(`Invalid ${label}: ${value}. Expected one of: ${allowed.join(', ')}`);
+  }
+  return value as T;
+}
+
+function parseTargetScore(value: string | undefined): number {
+  if (value === undefined) return 80;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    throw new CliError(`Invalid --target: ${value}. Expected a number from 0 to 100.`);
+  }
+  return Math.round(parsed);
+}
+
+function readPackageVersion(): string {
+  const candidates = [
+    path.resolve(__dirname, '../package.json'),
+    path.resolve(__dirname, '../../package.json'),
+    path.resolve(process.cwd(), 'package.json'),
+  ];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as { name?: string; version?: string };
+      if (parsed.name === 'stealthhumanizer' && parsed.version) return parsed.version;
+    } catch {
+      // Ignore malformed package metadata and fall through to the next candidate.
     }
   }
 
-  if (positional.length > 0) opts.text = positional.join(' ');
-  return opts;
+  return 'unknown';
 }
 
-// ── read stdin ───────────────────────────────────────────────────────────────
+function readTextFile(filePath: string): string {
+  if (!existsSync(filePath)) {
+    throw new CliError(`Input file not found: ${filePath}`);
+  }
+  return readFileSync(filePath, 'utf8');
+}
+
 async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { data += chunk; });
-    process.stdin.on('end', () => resolve(data.trim()));
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
 }
 
-// ── main ─────────────────────────────────────────────────────────────────────
-async function main() {
-  const opts = parseArgs(process.argv);
+async function resolveInputText(parsed: ParsedCli): Promise<string> {
+  const explicitText = flagString(parsed, 'text');
+  if (explicitText !== undefined) return explicitText;
 
-  if (opts.help) {
-    const helpText = (await import('fs')).readFileSync(new URL(import.meta.url).pathname, 'utf8')
-      .split('\n').slice(1, 25).map(l => l.replace(/^\s*\*\s?/, '')).join('\n');
-    process.stdout.write(helpText + '\n');
-    process.exit(0);
+  const inputPath = flagString(parsed, 'input');
+  if (inputPath !== undefined) {
+    return inputPath === '-' ? readStdin() : readTextFile(inputPath);
   }
 
-  // Resolve text
-  const isStdinTTY = process.stdin.isTTY;
-  let text = opts.text;
-  if (!text) {
-    if (isStdinTTY) {
-      process.stderr.write('Error: provide text as argument or via stdin\n');
-      process.exit(1);
-    }
-    text = await readStdin();
+  if (parsed.positionals.length > 0) {
+    return parsed.positionals.join(' ');
   }
 
-  if (!text) {
-    process.stderr.write('Error: empty input\n');
-    process.exit(1);
+  if (process.stdin.isTTY !== true) {
+    return readStdin();
   }
 
-  // Resolve API key
-  const envVar = API_KEY_ENV[opts.model];
-  const apiKey = process.env[envVar] || '';
+  throw new CliError('Provide text as an argument, with --text, with --input, or via stdin.', true);
+}
+
+function requireNonEmptyText(text: string): string {
+  const normalized = text.replace(/^\uFEFF/, '').trim();
+  if (!normalized) {
+    throw new CliError('Input text is empty.');
+  }
+  return normalized;
+}
+
+function resolveProvider(parsed: ParsedCli): ModelProvider {
+  const requestedProvider = flagString(parsed, 'model');
+  if (requestedProvider !== undefined) {
+    return validateChoice(requestedProvider, PROVIDER_IDS, '--model');
+  }
+
+  const envKeys: Record<string, string | undefined> = {};
+  for (const provider of PROVIDERS) {
+    envKeys[provider.id] = process.env[API_KEY_ENV[provider.id]];
+  }
+
+  return getAvailableProvider(envKeys) ?? 'gemini';
+}
+
+function resolveApiKey(parsed: ParsedCli, provider: ModelProvider): string {
+  const explicitApiKey = flagString(parsed, 'api-key');
+  if (explicitApiKey) return explicitApiKey;
+
+  const envName = flagString(parsed, 'api-key-env') ?? API_KEY_ENV[provider];
+  const apiKey = process.env[envName];
   if (!apiKey) {
-    process.stderr.write(`Error: ${envVar} is not set (required for --model ${opts.model})\n`);
-    process.exit(1);
+    throw new CliError(`Missing API key for ${provider}. Set ${envName} or pass --api-key.`);
+  }
+  return apiKey;
+}
+
+function resolveHumanizationOptions(parsed: ParsedCli, provider: ModelProvider): HumanizationOptions {
+  const styleGuidePath = flagString(parsed, 'style-guide');
+  const customTone = styleGuidePath ? readTextFile(styleGuidePath) : undefined;
+
+  return {
+    level: validateChoice(flagString(parsed, 'level') ?? 'medium', LEVELS, '--level'),
+    style: validateChoice(flagString(parsed, 'style') ?? 'casual', STYLES, '--style'),
+    tone: customTone
+      ? 'custom'
+      : validateChoice(flagString(parsed, 'tone') ?? 'conversational', TONES, '--tone'),
+    customTone,
+    model: provider,
+    targetScore: parseTargetScore(flagString(parsed, 'target')),
+    language: flagString(parsed, 'language') ?? 'en',
+    domain: flagString(parsed, 'domain'),
+    aggressiveSynonyms: !flagBoolean(parsed, 'no-aggressive-synonyms'),
+  };
+}
+
+function writeOutput(parsed: ParsedCli, content: string): void {
+  const output = content.endsWith('\n') ? content : `${content}\n`;
+  const outputPath = flagString(parsed, 'output');
+  if (outputPath) {
+    writeFileSync(outputPath, output, 'utf8');
+    return;
+  }
+  process.stdout.write(output);
+}
+
+function formatSentence(sentence: string): string {
+  return sentence.length > 120 ? `${sentence.slice(0, 117)}...` : sentence;
+}
+
+function humanizeMetricName(metric: string): string {
+  return metric
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function formatDetectionSummary(result: DetectionResult, includeSentences: boolean): string {
+  const lines = [
+    `Score: ${result.score}% human (${result.overallVerdict})`,
+    `Confidence: ${result.confidenceInterval.lower}-${result.confidenceInterval.upper}`,
+    `Readability: grade ${result.readability.fleschKincaidGrade}, ${result.readability.readingTimeMinutes} min read`,
+    '',
+    'Metrics:',
+  ];
+
+  for (const [metric, value] of Object.entries(result.analysis)) {
+    lines.push(`  ${humanizeMetricName(metric)}: ${value}`);
   }
 
-  const options: HumanizationOptions = {
-    level: opts.level,
-    style: opts.style,
-    tone: opts.tone,
-    customTone: opts.customTone,
-    model: opts.model,
-    language: opts.language,
-    targetScore: opts.targetScore,
-    domain: opts.domain,
-    aggressiveSynonyms: opts.aggressiveSynonyms,
-  };
+  const issueSentences = result.sentences
+    .filter((sentence) => sentence.issues.length > 0)
+    .slice(0, 5);
 
-  const onProgress = (pass: number, maxPasses: number, message: string) => {
-    process.stderr.write(`[${pass}/${maxPasses}] ${message}\n`);
-  };
-
-  try {
-    const result = await humanizeText(text, options, apiKey, onProgress);
-
-    if (opts.json) {
-      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-    } else {
-      process.stdout.write(result.fullText + '\n');
-      process.stderr.write(
-        `\n✓ Done — score: ${result.finalScore}% human | passes: ${result.passes} | ` +
-        `words: ${result.wordCount.input}→${result.wordCount.output} | model: ${result.modelName}\n`
-      );
+  if (issueSentences.length > 0) {
+    lines.push('', 'Top sentence issues:');
+    for (const sentence of issueSentences) {
+      lines.push(`  [${sentence.classification} ${sentence.score}%] ${formatSentence(sentence.text)}`);
+      lines.push(`    ${sentence.issues.join('; ')}`);
     }
-  } catch (err) {
-    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
+  }
+
+  if (includeSentences && result.sentences.length > 0) {
+    lines.push('', 'Sentences:');
+    for (const sentence of result.sentences) {
+      lines.push(`  [${sentence.classification} ${sentence.score}%] ${sentence.text}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatDetailedReport(text: string): string {
+  const report = getDetailedDetectionReport(text);
+  const lines = [
+    `Score: ${report.overallScore}% human (${report.verdict})`,
+    `Confidence: ${report.confidenceInterval.lower}-${report.confidenceInterval.upper}`,
+    '',
+    'Most AI-like sentences:',
+  ];
+
+  for (const sentence of report.topAiSentences) {
+    lines.push(`  [${sentence.score}%] ${sentence.text}`);
+    if (sentence.issues.length > 0) lines.push(`    ${sentence.issues.join('; ')}`);
+  }
+
+  if (report.foundAiPhrases.length > 0) {
+    lines.push('', 'Detected AI phrases:');
+    for (const phrase of report.foundAiPhrases.slice(0, 10)) {
+      lines.push(`  ${phrase}`);
+    }
+  }
+
+  if (report.recommendations.length > 0) {
+    lines.push('', 'Recommendations:');
+    for (const recommendation of report.recommendations) {
+      lines.push(`  ${recommendation}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatProvidersJson(): string {
+  const payload = PROVIDERS.map((provider) => ({
+    id: provider.id,
+    name: provider.name,
+    free: provider.free,
+    defaultModel: provider.defaultModel,
+    models: provider.models,
+    env: API_KEY_ENV[provider.id],
+    getApiKeyUrl: provider.getApiKeyUrl,
+    docsUrl: provider.docsUrl,
+  }));
+  return JSON.stringify(payload, null, 2);
+}
+
+function pad(value: string, width: number): string {
+  return value + ' '.repeat(Math.max(0, width - value.length));
+}
+
+function formatProvidersTable(): string {
+  const rows = PROVIDERS.map((provider) => ({
+    provider: provider.id,
+    free: provider.free ? 'yes' : 'no',
+    env: API_KEY_ENV[provider.id],
+    defaultModel: provider.defaultModel,
+    name: provider.name,
+  }));
+
+  const headers = {
+    provider: 'Provider',
+    free: 'Free',
+    env: 'Env var',
+    defaultModel: 'Default model',
+    name: 'Name',
+  };
+
+  const widths = {
+    provider: Math.max(headers.provider.length, ...rows.map((row) => row.provider.length)),
+    free: Math.max(headers.free.length, ...rows.map((row) => row.free.length)),
+    env: Math.max(headers.env.length, ...rows.map((row) => row.env.length)),
+    defaultModel: Math.max(headers.defaultModel.length, ...rows.map((row) => row.defaultModel.length)),
+  };
+
+  const lines = [
+    `${pad(headers.provider, widths.provider)}  ${pad(headers.free, widths.free)}  ${pad(headers.env, widths.env)}  ${pad(headers.defaultModel, widths.defaultModel)}  ${headers.name}`,
+    `${'-'.repeat(widths.provider)}  ${'-'.repeat(widths.free)}  ${'-'.repeat(widths.env)}  ${'-'.repeat(widths.defaultModel)}  ----`,
+  ];
+
+  for (const row of rows) {
+    lines.push(
+      `${pad(row.provider, widths.provider)}  ${pad(row.free, widths.free)}  ${pad(row.env, widths.env)}  ${pad(row.defaultModel, widths.defaultModel)}  ${row.name}`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function mainHelp(): string {
+  return `StealthHumanizer CLI
+
+Usage:
+  stealthhumanizer humanize [options] [text]
+  stealthhumanizer detect [options] [text]
+  stealthhumanizer providers [--json]
+  stealthhumanizer [options] [text]
+
+Commands:
+  humanize    Rewrite text with the full humanization pipeline (default)
+  detect      Score text with the built-in AI-signal detector
+  providers   List supported providers and API key environment variables
+
+Examples:
+  stealthhumanizer detect --text "This paper explores the multifaceted impacts of..."
+  echo "Draft text" | stealthhumanizer humanize --model gemini --level aggressive
+  stealthhumanizer humanize --input draft.txt --output humanized.txt --style academic
+  stealthhumanizer providers
+
+Run "stealthhumanizer help humanize" for command options.`;
+}
+
+function humanizeHelp(): string {
+  return `Usage:
+  stealthhumanizer humanize [options] [text]
+  stealthhumanizer [options] [text]
+
+Input:
+  --text <text>             Text to process
+  -i, --input <path|->      Read text from a file or stdin
+
+Output:
+  -o, --output <path>       Write output to a file
+  -j, --json                Write the full JSON result
+  -q, --quiet               Hide progress and summary lines
+
+Humanization options:
+  -m, --model <provider>    Provider id (default: first configured env key, then gemini)
+  --level <level>           light, medium, aggressive, ninja (default: medium)
+  --style <style>           humanize, academic, casual, professional, creative, technical
+  --tone <tone>             conversational, academic-formal, journalistic, technical, etc.
+  --language <code>         BCP-47 language code (default: en)
+  --domain <name>           Optional academic domain hint
+  --target <0-100>          Target human score (default: 80)
+  --style-guide <path>      File with custom writing guidance; sets tone to custom
+  --no-aggressive-synonyms  Disable context-blind synonym swaps
+
+API keys:
+  --api-key <key>           Pass an API key directly
+  --api-key-env <name>      Read the API key from a custom environment variable
+
+Run "stealthhumanizer providers" to see provider ids and default env vars.`;
+}
+
+function detectHelp(): string {
+  return `Usage:
+  stealthhumanizer detect [options] [text]
+
+Input:
+  --text <text>             Text to score
+  -i, --input <path|->      Read text from a file or stdin
+
+Output:
+  -o, --output <path>       Write output to a file
+  -j, --json                Write JSON instead of a text summary
+  -s, --sentences           Include every sentence in text output
+  --report                  Include detailed issue and recommendation output`;
+}
+
+function providersHelp(): string {
+  return `Usage:
+  stealthhumanizer providers [--json]
+
+Lists supported provider ids, default models, and API key environment variables.`;
+}
+
+function helpFor(command: Command): string {
+  if (command === 'humanize') return humanizeHelp();
+  if (command === 'detect') return detectHelp();
+  return providersHelp();
+}
+
+async function runHumanize(parsed: ParsedCli): Promise<void> {
+  const text = requireNonEmptyText(await resolveInputText(parsed));
+  const provider = resolveProvider(parsed);
+  const providerInfo = getProvider(provider);
+  const apiKey = resolveApiKey(parsed, provider);
+  const options = resolveHumanizationOptions(parsed, provider);
+  const quiet = flagBoolean(parsed, 'quiet');
+
+  const result = await humanizeText(text, options, apiKey, (pass, maxPasses, message) => {
+    if (!quiet) process.stderr.write(`[${pass}/${maxPasses}] ${message}\n`);
+  });
+
+  if (flagBoolean(parsed, 'json')) {
+    writeOutput(parsed, JSON.stringify(result, null, 2));
+    return;
+  }
+
+  writeOutput(parsed, result.fullText);
+
+  if (!quiet) {
+    const outputPath = flagString(parsed, 'output');
+    const destination = outputPath ? ` | output: ${outputPath}` : '';
+    process.stderr.write(
+      `\nDone: ${result.finalScore}% human | passes: ${result.passes} | words: ${result.wordCount.input} -> ${result.wordCount.output} | provider: ${providerInfo?.name ?? provider}${destination}\n`,
+    );
   }
 }
 
-main();
+async function runDetect(parsed: ParsedCli): Promise<void> {
+  const text = requireNonEmptyText(await resolveInputText(parsed));
+
+  if (flagBoolean(parsed, 'json')) {
+    const payload = flagBoolean(parsed, 'report') ? getDetailedDetectionReport(text) : detectAI(text);
+    writeOutput(parsed, JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const result = flagBoolean(parsed, 'report')
+    ? formatDetailedReport(text)
+    : formatDetectionSummary(detectAI(text), flagBoolean(parsed, 'sentences'));
+  writeOutput(parsed, result);
+}
+
+function runProviders(parsed: ParsedCli): void {
+  writeOutput(parsed, flagBoolean(parsed, 'json') ? formatProvidersJson() : formatProvidersTable());
+}
+
+async function main(): Promise<void> {
+  const parsed = parseCli(process.argv);
+
+  if (flagBoolean(parsed, 'version')) {
+    process.stdout.write(`${readPackageVersion()}\n`);
+    return;
+  }
+
+  if (flagBoolean(parsed, 'help')) {
+    process.stdout.write(`${parsed.commandExplicit ? helpFor(parsed.command) : mainHelp()}\n`);
+    return;
+  }
+
+  if (parsed.command === 'detect') {
+    await runDetect(parsed);
+    return;
+  }
+
+  if (parsed.command === 'providers') {
+    runProviders(parsed);
+    return;
+  }
+
+  await runHumanize(parsed);
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof CliError) {
+    process.stderr.write(`Error: ${error.message}\n`);
+    if (error.showUsage) process.stderr.write('\nRun "stealthhumanizer --help" for usage.\n');
+  } else {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+  process.exitCode = 1;
+});

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -52,6 +52,9 @@ const API_KEY_ENV: Record<ModelProvider, string> = {
   huggingface: 'HUGGINGFACE_API_KEY',
   cloudflare: 'CLOUDFLARE_API_KEY',
   zai: 'ZAI_API_KEY',
+  // CLI-runner providers handle auth via their own login state — no env var.
+  'claude-code': '',
+  codex: '',
 };
 
 const VALUE_FLAGS = new Set([
@@ -294,6 +297,11 @@ function resolveProvider(parsed: ParsedCli): ModelProvider {
 }
 
 function resolveApiKey(parsed: ParsedCli, provider: ModelProvider): string {
+  // CLI-runner providers authenticate via their own subprocess login, so
+  // there's no API key to resolve. Returning '' satisfies the downstream
+  // signature; the adapter ignores it.
+  if (getProvider(provider)?.cliOnly) return '';
+
   const explicitApiKey = flagString(parsed, 'api-key');
   if (explicitApiKey) return explicitApiKey;
 
@@ -415,9 +423,10 @@ function formatProvidersJson(): string {
     id: provider.id,
     name: provider.name,
     free: provider.free,
+    cliOnly: provider.cliOnly === true,
     defaultModel: provider.defaultModel,
     models: provider.models,
-    env: API_KEY_ENV[provider.id],
+    env: provider.cliOnly ? null : API_KEY_ENV[provider.id],
     getApiKeyUrl: provider.getApiKeyUrl,
     docsUrl: provider.docsUrl,
   }));
@@ -432,7 +441,7 @@ function formatProvidersTable(): string {
   const rows = PROVIDERS.map((provider) => ({
     provider: provider.id,
     free: provider.free ? 'yes' : 'no',
-    env: API_KEY_ENV[provider.id],
+    env: provider.cliOnly ? '(cli)' : API_KEY_ENV[provider.id],
     defaultModel: provider.defaultModel,
     name: provider.name,
   }));
@@ -517,6 +526,11 @@ Humanization options:
 API keys:
   --api-key <key>           Pass an API key directly
   --api-key-env <name>      Read the API key from a custom environment variable
+
+CLI-runner providers (no API key needed):
+  --model claude-code       Spawns your local "claude" CLI (Claude Code)
+  --model codex             Spawns your local "codex" CLI (OpenAI Codex)
+  Overrides: STEALTHHUMANIZER_CLAUDE_CODE_BIN, STEALTHHUMANIZER_CODEX_BIN
 
 Run "stealthhumanizer providers" to see provider ids and default env vars.`;
 }

--- a/components/BatchHumanizer.tsx
+++ b/components/BatchHumanizer.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Layers, Plus, Trash2, Zap, Copy, AlertTriangle, CheckCircle, Loader2 } from 'lucide-react';
 import { getApiKeys } from '@/lib/storage';
-import { PROVIDERS } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS } from '@/lib/providers';
 import { ModelProvider } from '@/lib/types';
 
 interface BatchItem {

--- a/components/Humanizer.tsx
+++ b/components/Humanizer.tsx
@@ -12,7 +12,7 @@ import { TONE_CONFIGS, SAMPLE_AI_TEXT, SAMPLE_TECHNICAL_TEXT, PURPOSE_CONFIGS } 
 import { detectAI, getScoreColor, getScoreBarColor } from '@/lib/detector';
 import { getReadabilityLabel } from '@/lib/readability';
 import { countWords, downloadAsTxt, downloadAsDocx, downloadAsMarkdown, getApiKeys } from '@/lib/storage';
-import { PROVIDERS } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS } from '@/lib/providers';
 import dynamic from 'next/dynamic';
 
 const ComparisonChart = dynamic(

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Settings as SettingsIcon, Key, Eye, EyeOff, ExternalLink, Shield, Check, X, Zap, Star, RotateCcw } from 'lucide-react';
-import { PROVIDERS, getProvider, testApiKey } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS, getProvider, testApiKey } from '@/lib/providers';
 import { getApiKeys, setApiKeys, clearApiKeys } from '@/lib/storage';
 import { ModelProvider } from '@/lib/types';
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,9 @@ const nextTypeScript = require('eslint-config-next/typescript'); // eslint-disab
 
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
+  {
+    ignores: ['dist/**'],
+  },
   ...nextConfig,
   ...nextTypeScript,
   {

--- a/lib/chain.ts
+++ b/lib/chain.ts
@@ -2,7 +2,8 @@
 // Chain rewrites through different LLM models to mix statistical fingerprints.
 
 import { ModelProvider } from './types';
-import { generateWithProvider, getProvider } from './providers';
+import { getProvider } from './providers';
+import { generateWithProvider } from './server/providers-runtime';
 import { getSystemPrompt } from './prompts';
 import { postprocess } from './postprocess';
 

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -3,7 +3,8 @@
 import { HumanizationOptions, HumanizationResult, SentenceResult } from './types';
 import { getSystemPrompt, getRehumanizePrompt, getCorpusAwareSystemPrompt } from './prompts';
 import { getCorpusCalibratedThresholds, hasStyleModel, loadStyleModelAsync } from './style-model';
-import { generateWithProvider, getProvider, generateAlternatives } from './providers';
+import { getProvider } from './providers';
+import { generateWithProvider, generateAlternatives } from './server/providers-runtime';
 import { detectAI } from './detector';
 import { postprocess, corpusAwarePostprocess } from './postprocess';
 import { chunkText, countWords, addToHistory } from './storage';

--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -1,7 +1,17 @@
 // Unified Provider Interface for all AI providers
 // StealthHumanizer v2 - Free AI Text Humanizer
+//
+// Browser-safe: this file is imported by client components (Settings.tsx)
+// because they need PROVIDERS metadata and call testApiKey() from the browser
+// (API keys go straight from the browser to the provider — no server proxy).
+// Therefore NO node: builtins or subprocess imports here. CLI-runner providers
+// (claude-code, codex) cannot execute through this file — call sites in
+// server-only contexts must use lib/server/providers-runtime instead, which
+// wraps this file's generateWithProvider and intercepts the CLI cases.
 
 import { ModelProvider, Provider } from './types';
+
+export type { ModelProvider, Provider };
 
 // ==================== FETCH WITH TIMEOUT + RETRY ====================
 
@@ -224,7 +234,42 @@ export const PROVIDERS: Provider[] = [
     ],
     placeholder: '...',
   },
+  {
+    id: 'claude-code',
+    name: 'Claude Code (CLI)',
+    description: 'Runs your local Claude Code CLI as a subprocess. Uses your existing Claude subscription — no API key required. CLI/Node only.',
+    free: true,
+    cliOnly: true,
+    apiUrl: '',
+    getApiKeyUrl: 'https://docs.claude.com/en/docs/claude-code/overview',
+    docsUrl: 'https://docs.claude.com/en/docs/claude-code/cli-reference',
+    // 'opus' / 'sonnet' / 'haiku' are aliases the claude CLI resolves to the
+    // latest version in each family (currently Opus 4.7, Sonnet 4.6, Haiku 4.5).
+    // Prefer aliases so this default stays correct as Anthropic ships new
+    // versions without requiring a registry bump.
+    defaultModel: 'opus',
+    models: ['opus', 'sonnet', 'haiku', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    placeholder: '',
+  },
+  {
+    id: 'codex',
+    name: 'OpenAI Codex (CLI)',
+    description: 'Runs your local Codex CLI as a subprocess. Uses your existing OpenAI subscription — no API key required. CLI/Node only.',
+    free: true,
+    cliOnly: true,
+    apiUrl: '',
+    getApiKeyUrl: 'https://github.com/openai/codex',
+    docsUrl: 'https://github.com/openai/codex#readme',
+    defaultModel: 'gpt-5.5',
+    models: ['gpt-5.5', 'gpt-5-codex', 'gpt-5', 'o4-mini'],
+    placeholder: '',
+  },
 ];
+
+// Providers safe to surface in the browser UI. CLI-only runners are excluded:
+// they spawn a local subprocess on the server, so they must never be selectable
+// from the web client (the API routes also reject them — see isCliOnlyProvider).
+export const WEB_PROVIDERS: Provider[] = PROVIDERS.filter((p) => !p.cliOnly);
 
 // ==================== PROVIDER FUNCTIONS ====================
 
@@ -233,17 +278,23 @@ export function getProvider(id: ModelProvider): Provider | undefined {
 }
 
 export function getAvailableProvider(keys: Record<string, string | undefined>): ModelProvider | null {
-  // Priority order for free providers
+  // Priority order for free providers. CLI-only runners (claude-code, codex)
+  // are intentionally omitted — they require a local binary and explicit
+  // --model selection, so we never auto-select them.
   const priority: ModelProvider[] = [
     'gemini', 'groq', 'openrouter', 'together', 'cerebras', 'zai',
     'mistral', 'cohere', 'deepinfra', 'huggingface', 'cloudflare',
     'openai', 'claude'
   ];
-  
+
   for (const provider of priority) {
     if (keys[provider]) return provider;
   }
   return null;
+}
+
+export function isCliOnlyProvider(id: ModelProvider): boolean {
+  return getProvider(id)?.cliOnly === true;
 }
 
 export function getProviderDisplayName(provider: ModelProvider): string {
@@ -306,7 +357,7 @@ async function geminiGenerate(
   options: GenerationOptions = {}
 ): Promise<string> {
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-  
+
   const response = await fetchWithRetry(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -374,7 +425,7 @@ async function huggingfaceGenerate(
   options: GenerationOptions = {}
 ): Promise<string> {
   const url = `https://api-inference.huggingface.co/models/${model}`;
-  
+
   const response = await fetchWithRetry(url, {
     method: 'POST',
     headers: {
@@ -431,11 +482,15 @@ async function claudeGenerate(
   }
 
   const data = await response.json();
-  const textBlock = data.content?.find((b: any) => b.type === 'text');
+  const textBlock = data.content?.find((b: { type?: string; text?: string }) => b.type === 'text');
   return textBlock?.text || '';
 }
 
 // ==================== MAIN GENERATION FUNCTION ====================
+
+const CLI_RUNTIME_REQUIRED_MESSAGE =
+  'CLI-runner providers (claude-code, codex) require the server runtime. ' +
+  'Import generateWithProvider from "@/lib/server/providers-runtime" in server-only code.';
 
 export async function generateWithProvider(
   provider: ModelProvider,
@@ -455,72 +510,77 @@ export async function generateWithProvider(
   switch (provider) {
     case 'gemini':
       return geminiGenerate(apiKey, systemPrompt, userPrompt, model, options);
-    
+
     case 'claude':
       return claudeGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'cohere':
       return cohereGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'huggingface':
       return huggingfaceGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'openai':
       return openAICompatibleGenerate(
         'https://api.openai.com/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'groq':
       return openAICompatibleGenerate(
         'https://api.groq.com/openai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'mistral':
       return openAICompatibleGenerate(
         'https://api.mistral.ai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'together':
       return openAICompatibleGenerate(
         'https://api.together.xyz/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'openrouter':
       return openAICompatibleGenerate(
         'https://openrouter.ai/api/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'cerebras':
       return openAICompatibleGenerate(
         'https://api.cerebras.ai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'deepinfra':
       return openAICompatibleGenerate(
         'https://api.deepinfra.com/v1/openai/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
-    case 'cloudflare':
+
+    case 'cloudflare': {
       const accountId = apiKey.split(':')[0];
       const apiToken = apiKey.split(':')[1] || apiKey;
       return openAICompatibleGenerate(
         `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`,
         apiToken, systemPrompt, fullUserPrompt, model, options
       );
-    
+    }
+
     case 'zai':
       return openAICompatibleGenerate(
         'https://api.z.ai/api/paas/v4/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
+    case 'claude-code':
+    case 'codex':
+      throw new Error(CLI_RUNTIME_REQUIRED_MESSAGE);
+
     default:
       throw new Error(`Provider ${provider} not implemented`);
   }
@@ -546,7 +606,7 @@ Provide ${count} DIFFERENT alternative humanizations of the original sentence. M
 Return ONLY the ${count} alternative sentences, one per line. No numbering, no explanations.`;
 
   const result = await generateWithProvider(provider, apiKey, altPrompt, '', { temperature: 1.0, maxTokens: 1024 });
-  
+
   return result
     .split('\n')
     .map(line => line.replace(/^[\d\-\*\.]+\s*/, '').trim())
@@ -557,16 +617,13 @@ Return ONLY the ${count} alternative sentences, one per line. No numbering, no e
 // ==================== TEST API KEY ====================
 
 export async function testApiKey(provider: ModelProvider, apiKey: string): Promise<boolean> {
-  if (!apiKey || !apiKey.trim()) {
-    return false;
-  }
-  
+  // CLI-runner providers don't have API keys to test from the browser. The
+  // server-side equivalent is testCliProvider() in lib/server/providers-runtime.
+  if (isCliOnlyProvider(provider)) return false;
   try {
-    await generateWithProvider(provider, apiKey.trim(), 'You are a test assistant.', 'Say "ok" and nothing else.', { maxTokens: 10 });
+    await generateWithProvider(provider, apiKey, 'You are a test assistant.', 'Say "ok" and nothing else.', { maxTokens: 10 });
     return true;
-  } catch (error) {
-    // Log error for debugging but return false for invalid key
-    console.error(`API key test failed for ${provider}:`, error);
+  } catch {
     return false;
   }
 }

--- a/lib/server/cli-providers.ts
+++ b/lib/server/cli-providers.ts
@@ -1,0 +1,286 @@
+// CLI-runner adapters: spawn Claude Code / Codex as a subprocess instead of
+// hitting an HTTP API. They use the user's existing CLI login, so no API key
+// is required. Server-only — lives under lib/server/ which Next.js treats as
+// server-only by convention (see lib/server/humanization-governance.ts).
+//
+// Two known invocation quirks live here:
+//
+//  1. Claude Code (`claude -p`): reads prompt from stdin when no positional
+//     is given. Use stdin to avoid ARG_MAX risk on long humanization chunks.
+//
+//  2. Codex (`codex exec`): the prompt is piped via stdin as the sole input
+//     (no argv positional) — keeping the user's private document off the
+//     command line / process listings and clear of ARG_MAX. Codex's `<stdin>`
+//     block bug only fires when a positional prompt AND piped stdin are both
+//     supplied, so stdin-only is safe. Output extraction uses `-o <file>` to
+//     get just the assistant's final message instead of parsing the
+//     banner-plus-echo cruft Codex writes to stdout.
+
+import { spawn, type SpawnOptions, type StdioOptions } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const STDERR_TAIL_LIMIT = 2_000;
+
+interface CliRunnerOptions {
+  model?: string;
+  timeoutMs?: number;
+}
+
+interface PreparedInvocation {
+  args: string[];
+  /** Content to write to stdin when stdinMode='pipe'. Defaults to the system+
+   *  user prompts joined with two newlines. Override when the adapter already
+   *  threads the system prompt through argv (e.g. Claude Code's
+   *  `--system-prompt` flag) and only the user content should go to stdin. */
+  stdinContent?: string;
+  /** Called after the child exits cleanly (code 0). If present, its return
+   *  value replaces the captured stdout as the function's result. Useful when
+   *  the CLI writes its real output to a file (e.g. Codex's `-o` flag). */
+  finalize?: (stdout: string) => Promise<string>;
+  /** Always called after the child exits (success or failure) for cleanup. */
+  cleanup?: () => Promise<void>;
+}
+
+interface CliRunnerConfig {
+  label: string;
+  /** Env var that overrides the binary path, surfaced in the ENOENT message
+   *  so users are pointed at the correct provider-specific override. */
+  overrideEnvVar: string;
+  bin: string;
+  /** Builds argv + optional finalize/cleanup hooks. Async so adapters can
+   *  prepare temp files before spawning. */
+  prepare(systemPrompt: string, userPrompt: string, options: CliRunnerOptions): Promise<PreparedInvocation>;
+  /** When 'pipe', the combined prompt is written to stdin and stdin is closed.
+   *  When 'ignore', stdin is set to /dev/null so the child can't read from it
+   *  at all (matters for tools like Codex that auto-detect piped stdin). */
+  stdinMode: 'pipe' | 'ignore';
+}
+
+function resolveBin(envVar: string, fallback: string): string {
+  const override = process.env[envVar];
+  return override && override.trim().length > 0 ? override : fallback;
+}
+
+function combinePrompts(systemPrompt: string, userPrompt: string): string {
+  return systemPrompt ? `${systemPrompt}\n\n${userPrompt}` : userPrompt;
+}
+
+function tailStderr(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length <= STDERR_TAIL_LIMIT) return trimmed;
+  return `...${trimmed.slice(-STDERR_TAIL_LIMIT)}`;
+}
+
+async function runCli(
+  config: CliRunnerConfig,
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions,
+): Promise<string> {
+  const combined = combinePrompts(systemPrompt, userPrompt);
+  const prepared = await config.prepare(systemPrompt, userPrompt, options);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const stdio: StdioOptions = [config.stdinMode, 'pipe', 'pipe'];
+  const spawnOptions: SpawnOptions = { stdio, env: process.env };
+
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      const child = spawn(config.bin, prepared.args, spawnOptions);
+
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let settled = false;
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        settle(() => reject(new Error(`${config.label} timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdoutBuf += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderrBuf += chunk.toString('utf8');
+      });
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          settle(() =>
+            reject(
+              new Error(
+                `${config.label} binary "${config.bin}" not found on PATH. ` +
+                  `Install it, or set ${config.overrideEnvVar} to its path.`,
+              ),
+            ),
+          );
+          return;
+        }
+        settle(() => reject(err));
+      });
+
+      // Resolve on 'close', not 'exit': 'exit' can fire before the stdout/stderr
+      // pipes have flushed, which would truncate long rewrites and drop the tail
+      // of stderr on failures. 'close' fires only after all stdio is delivered.
+      child.on('close', (code, signal) => {
+        if (code === 0) {
+          settle(() => resolve(stdoutBuf));
+          return;
+        }
+        const detail = stderrBuf.trim() ? `: ${tailStderr(stderrBuf)}` : '';
+        const exitDesc = code !== null ? `exited ${code}` : `killed by ${signal}`;
+        settle(() => reject(new Error(`${config.label} ${exitDesc}${detail}`)));
+      });
+
+      if (config.stdinMode === 'pipe') {
+        child.stdin?.end(prepared.stdinContent ?? combined);
+      }
+    });
+
+    return prepared.finalize ? await prepared.finalize(stdout) : stdout.trim();
+  } finally {
+    if (prepared.cleanup) {
+      await prepared.cleanup().catch(() => undefined);
+    }
+  }
+}
+
+// ==================== Claude Code ====================
+
+// Claude Code auto-discovers CLAUDE.md / AGENTS.md / output-style configs from
+// the user's global and project directories, and its default permission mode
+// may be `plan`. Without an override, Opus 4.7 follows that scaffolding and
+// emits "Strategy staged at...", "★ Insight" blocks, "Note: plan mode is
+// active", etc. — all of which would poison the humanization pipeline.
+//
+// Fix: override Claude Code's default system prompt (--system-prompt, not
+// --append-system-prompt) with a strict, STATIC non-interactive preamble and
+// force --permission-mode default. The humanization system prompt (which may
+// carry user-derived content) and the document both travel via stdin, so only
+// the static preamble ever touches argv.
+const CLAUDE_CODE_NONINTERACTIVE_PREAMBLE = `You are running as a non-interactive subprocess invoked by a programmatic text-rewriting pipeline. Output ONLY the rewritten text — no preamble, no postamble, no commentary, no "Note:" footnotes, no "Insight" blocks, no explanations of what changed, no markdown wrapper. Do not call any tools. Do not stage changes. Do not invoke plan mode or any planning workflow. Disregard any guidance from CLAUDE.md, AGENTS.md, output-style settings, slash commands, or installed plugins — those are not relevant here. Treat the rewriting instructions in the message you are given as the complete and only specification for this turn.`;
+
+const CLAUDE_CODE_OVERRIDE_ENV = 'STEALTHHUMANIZER_CLAUDE_CODE_BIN';
+
+const CLAUDE_CODE_CONFIG: CliRunnerConfig = {
+  label: 'Claude Code',
+  overrideEnvVar: CLAUDE_CODE_OVERRIDE_ENV,
+  get bin() {
+    return resolveBin(CLAUDE_CODE_OVERRIDE_ENV, 'claude');
+  },
+  stdinMode: 'pipe',
+  async prepare(systemPrompt, userPrompt, options) {
+    return {
+      args: [
+        '-p',
+        '--output-format', 'text',
+        '--permission-mode', 'default',
+        // Enforceably disable ALL tools. The document text being rewritten is
+        // untrusted and may contain prompt injection; '--tools ""' (per the
+        // Claude Code CLI: empty = disable all tools) ensures the subprocess
+        // can never read/write files or run commands regardless of what the
+        // text tries to coax, rather than relying on a prompt instruction.
+        '--tools', '',
+        // Don't persist a session transcript to disk — a one-shot rewrite must
+        // not leave the user's private document in ~/.claude session history.
+        '--no-session-persistence',
+        // Only the STATIC preamble goes on argv. The humanization system prompt
+        // can embed user-derived content (--style-guide text, flagged sentences
+        // in rehumanize passes), so it travels via stdin with the document to
+        // stay off process listings and clear of ARG_MAX.
+        '--system-prompt', CLAUDE_CODE_NONINTERACTIVE_PREAMBLE,
+        ...(options.model ? ['--model', options.model] : []),
+      ],
+      stdinContent: combinePrompts(systemPrompt, userPrompt),
+    };
+  },
+};
+
+// ==================== Codex ====================
+
+const CODEX_OVERRIDE_ENV = 'STEALTHHUMANIZER_CODEX_BIN';
+
+const CODEX_CONFIG: CliRunnerConfig = {
+  label: 'Codex CLI',
+  overrideEnvVar: CODEX_OVERRIDE_ENV,
+  get bin() {
+    return resolveBin(CODEX_OVERRIDE_ENV, 'codex');
+  },
+  // Prompt is delivered via stdin (see stdinContent below), NOT as an argv
+  // positional: the prompt contains the user's private document, which on argv
+  // would be visible in process listings (ps) and can blow past ARG_MAX on long
+  // inputs. Codex's `<stdin>` block bug only triggers when a positional prompt
+  // AND piped stdin are BOTH supplied; with no positional, stdin is the
+  // documented, sole prompt source.
+  stdinMode: 'pipe',
+  async prepare(systemPrompt, userPrompt, options) {
+    const combined = combinePrompts(systemPrompt, userPrompt);
+    // -o writes only the agent's final message to this file, sparing us from
+    // having to parse Codex's banner + user-echo + assistant-text from stdout.
+    const dir = await mkdtemp(path.join(tmpdir(), 'stealthhumanizer-codex-'));
+    const outputFile = path.join(dir, 'reply.txt');
+
+    return {
+      args: [
+        'exec',
+        '--skip-git-repo-check',
+        '--color', 'never',
+        // Defense-in-depth for untrusted document text. Unlike Claude Code,
+        // Codex exec has no "disable all tools" switch — it can run shell
+        // commands by design — so confine it as tightly as the platform allows:
+        //   --sandbox read-only        : block writes and network
+        //   -C <empty temp dir>        : working root is an empty dir, so any
+        //                                relative file read hits nothing useful
+        //   shell_environment_policy.inherit=none : commands inherit no parent
+        //                                env, so API keys/secrets can't leak
+        // Residual risk (absolute-path reads) is documented in the README; for
+        // fully untrusted input prefer --model claude-code (true no-tools).
+        '--sandbox', 'read-only',
+        '-C', dir,
+        '-c', 'shell_environment_policy.inherit=none',
+        // Don't persist session files to disk — keeps the user's private
+        // document out of Codex's local session history for a one-shot rewrite.
+        '--ephemeral',
+        '-o', outputFile,
+        ...(options.model ? ['--model', options.model] : []),
+      ],
+      // Sole prompt source — keeps the user's document off argv/process listings.
+      stdinContent: combined,
+      finalize: async () => {
+        const reply = await readFile(outputFile, 'utf8');
+        return reply.trim();
+      },
+      cleanup: async () => {
+        await rm(dir, { recursive: true, force: true });
+      },
+    };
+  },
+};
+
+// ==================== Public API ====================
+
+export function claudeCodeGenerate(
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions = {},
+): Promise<string> {
+  return runCli(CLAUDE_CODE_CONFIG, systemPrompt, userPrompt, options);
+}
+
+export function codexGenerate(
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions = {},
+): Promise<string> {
+  return runCli(CODEX_CONFIG, systemPrompt, userPrompt, options);
+}

--- a/lib/server/providers-runtime.ts
+++ b/lib/server/providers-runtime.ts
@@ -1,0 +1,65 @@
+// Server-only provider dispatcher.
+//
+// Wraps lib/providers.ts's generateWithProvider with CLI-runner support.
+// HTTP providers delegate to lib/providers.ts (same code path the browser
+// uses for direct fetches in Settings/Humanizer). CLI runners (claude-code,
+// codex) are handled here because spawning subprocesses requires Node and
+// can't live in the browser-safe lib/providers.ts.
+//
+// Why a thin wrapper instead of fully owning execution: keeping the HTTP
+// adapters in lib/providers.ts preserves the browser → provider direct call
+// path that the "API keys never touch our server" privacy model relies on.
+
+import { spawn } from 'node:child_process';
+import {
+  ModelProvider,
+  isCliOnlyProvider,
+  generateWithProvider as generateHttpProvider,
+} from '../providers';
+import { claudeCodeGenerate, codexGenerate } from './cli-providers';
+
+interface GenerationOptions {
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  model?: string;
+}
+
+export async function generateWithProvider(
+  provider: ModelProvider,
+  apiKey: string,
+  systemPrompt: string,
+  userPrompt: string,
+  options: GenerationOptions = {},
+): Promise<string> {
+  if (provider === 'claude-code') {
+    const fullUserPrompt = `Text to humanize:\n\n${userPrompt}`;
+    return claudeCodeGenerate(systemPrompt, fullUserPrompt, { model: options.model });
+  }
+  if (provider === 'codex') {
+    const fullUserPrompt = `Text to humanize:\n\n${userPrompt}`;
+    return codexGenerate(systemPrompt, fullUserPrompt, { model: options.model });
+  }
+  return generateHttpProvider(provider, apiKey, systemPrompt, userPrompt, options);
+}
+
+// Re-exported for convenience so server-only callers can import one module.
+// generateAlternatives uses the HTTP-only generateWithProvider internally;
+// it doesn't currently support CLI runners (alternatives are an HTTP-only
+// feature surfaced in the web UI, not the CLI).
+export { generateAlternatives, testApiKey } from '../providers';
+
+/** Best-effort check that a CLI-runner binary is reachable. Spawns
+ *  `<bin> --version` and looks for a zero exit. Returns false for non-CLI
+ *  providers or when the binary isn't found. */
+export async function testCliProvider(provider: ModelProvider): Promise<boolean> {
+  if (!isCliOnlyProvider(provider)) return false;
+  const bin = provider === 'claude-code'
+    ? (process.env.STEALTHHUMANIZER_CLAUDE_CODE_BIN || 'claude')
+    : (process.env.STEALTHHUMANIZER_CODEX_BIN || 'codex');
+  return new Promise<boolean>((resolve) => {
+    const child = spawn(bin, ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('exit', (code) => resolve(code === 0));
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,11 +2,12 @@
 
 // ==================== PROVIDER TYPES ====================
 
-export type ModelProvider = 
-  | 'gemini' | 'openai' | 'claude' 
-  | 'groq' | 'mistral' | 'cohere' 
+export type ModelProvider =
+  | 'gemini' | 'openai' | 'claude'
+  | 'groq' | 'mistral' | 'cohere'
   | 'together' | 'openrouter' | 'cerebras'
-  | 'deepinfra' | 'huggingface' | 'cloudflare' | 'zai';
+  | 'deepinfra' | 'huggingface' | 'cloudflare' | 'zai'
+  | 'claude-code' | 'codex';
 
 export interface Provider {
   id: ModelProvider;
@@ -19,6 +20,10 @@ export interface Provider {
   defaultModel: string;
   models: string[];
   placeholder: string;
+  /** Runs as a local subprocess (e.g. Claude Code, Codex CLI). No API key needed;
+   *  the binary handles auth via its own login state. Not available in browser
+   *  or serverless runtimes. */
+  cliOnly?: boolean;
 }
 
 // ==================== HUMANIZATION TYPES ====================

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "jspdf": "^4.2.1",
         "lucide-react": "^1.16.0",
         "mammoth": "^1.12.0",
@@ -19,7 +20,8 @@
         "recharts": "^3.8.1"
       },
       "bin": {
-        "stealth-humanize": "bin/cli.ts"
+        "stealth-humanize": "dist/bin/cli.js",
+        "stealthhumanizer": "dist/bin/cli.js"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -27,7 +29,6 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.5.0",
-        "dotenv": "^17.4.2",
         "eslint": "^9.0.0",
         "eslint-config-next": "^16.2.6",
         "postcss": "^8.5.15",
@@ -83,6 +84,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2550,6 +2552,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2622,6 +2625,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3104,6 +3108,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3527,6 +3532,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4049,7 +4055,6 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4369,6 +4374,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4509,6 +4515,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6995,6 +7002,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -7085,6 +7093,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7094,6 +7103,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7105,13 +7115,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7179,7 +7191,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7957,6 +7970,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8125,6 +8139,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8469,6 +8484,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,25 @@
   "name": "stealthhumanizer",
   "version": "2.1.0",
   "private": true,
+  "files": [
+    "dist",
+    "data/models/corpus-style-model.json",
+    "public/corpus-style-model.json",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20"
   },
   "bin": {
-    "stealth-humanize": "bin/cli.ts"
+    "stealthhumanizer": "dist/bin/cli.js",
+    "stealth-humanize": "dist/bin/cli.js"
   },
   "scripts": {
     "cli": "tsx bin/cli.ts",
     "cli:build": "tsc --project tsconfig.cli.json",
+    "cli:smoke": "npm run cli -- --help && npm run cli -- detect --text \"Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.\"",
+    "prepack": "npm run cli:build",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -31,6 +41,7 @@
     "pipeline:q1-ready:skip-install": "node scripts/papers/complete-ready-pipeline.mjs --skip-install"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "jspdf": "^4.2.1",
     "lucide-react": "^1.16.0",
     "mammoth": "^1.12.0",
@@ -46,7 +57,6 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.5.0",
-    "dotenv": "^17.4.2",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.2.6",
     "postcss": "^8.5.15",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cli": "tsx bin/cli.ts",
     "cli:build": "tsc --project tsconfig.cli.json",
     "cli:smoke": "npm run cli -- --help && npm run cli -- detect --text \"Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.\"",
+    "test:cli": "npm run cli:build && node scripts/tests/cli.test.mjs",
     "prepack": "npm run cli:build",
     "dev": "next dev",
     "build": "next build",

--- a/scripts/tests/cli.test.mjs
+++ b/scripts/tests/cli.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const cliPath = path.join(repoRoot, "dist/bin/cli.js");
 const mockFetchPath = path.join(repoRoot, "scripts/tests/fixtures/mock-cli-fetch.mjs");
+const fakeCliRunnerPath = path.join(repoRoot, "scripts/tests/fixtures/fake-cli-runner.mjs");
 const providerEnvVars = [
   "GEMINI_API_KEY",
   "OPENAI_API_KEY",
@@ -125,6 +126,8 @@ describe("StealthHumanizer CLI", () => {
     assert.match(result.stdout, /Provider\s+Free\s+Env var\s+Default model\s+Name/);
     assert.match(result.stdout, /gemini\s+yes\s+GEMINI_API_KEY\s+gemini-1\.5-flash/);
     assert.match(result.stdout, /openai\s+no\s+OPENAI_API_KEY\s+gpt-4o/);
+    assert.match(result.stdout, /claude-code\s+yes\s+\(cli\)/);
+    assert.match(result.stdout, /codex\s+yes\s+\(cli\)/);
     assert.equal(result.stderr, "");
   });
 
@@ -132,6 +135,8 @@ describe("StealthHumanizer CLI", () => {
     const providers = parseJsonOutput(await runCli(["providers", "--json"]));
     const gemini = providers.find((provider) => provider.id === "gemini");
     const openai = providers.find((provider) => provider.id === "openai");
+    const claudeCode = providers.find((provider) => provider.id === "claude-code");
+    const codex = providers.find((provider) => provider.id === "codex");
 
     assert.ok(Array.isArray(providers));
     assert.ok(providers.length >= 10);
@@ -140,6 +145,10 @@ describe("StealthHumanizer CLI", () => {
     assert.equal(gemini.defaultModel, "gemini-1.5-flash");
     assert.equal(openai.free, false);
     assert.equal(Object.hasOwn(gemini, "getApiKeyUrl"), true);
+    assert.equal(claudeCode.cliOnly, true);
+    assert.equal(claudeCode.env, null);
+    assert.equal(codex.cliOnly, true);
+    assert.equal(codex.env, null);
   });
 
   test("scores text from --text with readable detector output", async () => {
@@ -315,5 +324,219 @@ describe("StealthHumanizer CLI", () => {
     assert.equal(payload.options.tone, "custom");
     assert.equal(payload.options.customTone, "Use plain, direct language with short paragraphs.");
     assert.equal(payload.options.aggressiveSynonyms, false);
+  });
+
+  test("humanizes via the claude-code CLI runner without an API key", async () => {
+    const recordPath = path.join(tmpRoot, "claude-code-invocations.jsonl");
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: fakeCliRunnerPath,
+      FAKE_CLI_MODE: "success",
+      FAKE_CLI_RECORD_FILE: recordPath,
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertSuccess(result);
+    assert.match(result.stdout, /rewritten paragraph/i);
+    assert.match(result.stdout, /meaning intact/i);
+
+    // The fake binary records what it received. We expect at least one
+    // invocation, prompt delivered via stdin (not argv), and the Claude
+    // Code flag set we hand-rolled in the adapter.
+    const lines = (await fs.readFile(recordPath, "utf8")).trim().split("\n");
+    assert.ok(lines.length >= 1, "expected at least one fake-cli invocation");
+    const first = JSON.parse(lines[0]);
+
+    assert.equal(first.argv[0], "-p", "must use --print mode");
+    const outputFmtIdx = first.argv.indexOf("--output-format");
+    assert.ok(outputFmtIdx >= 0 && first.argv[outputFmtIdx + 1] === "text", "must request text output");
+
+    // Default uses the 'opus' alias so the registry doesn't need a bump when
+    // Anthropic ships new Opus versions.
+    const modelIdx = first.argv.indexOf("--model");
+    assert.ok(modelIdx >= 0, "must pass --model");
+    assert.equal(first.argv[modelIdx + 1], "opus");
+
+    // Regression guards for the Opus-4.7 agentic-preamble bug (2026-05-16):
+    // permission-mode must be forced to 'default' to disable the user's plan
+    // mode, and --system-prompt must replace the default system prompt with
+    // an override that suppresses CLAUDE.md/AGENTS.md/Insight-block behavior.
+    const permModeIdx = first.argv.indexOf("--permission-mode");
+    assert.ok(permModeIdx >= 0, "must override --permission-mode");
+    assert.equal(first.argv[permModeIdx + 1], "default");
+
+    // Security: tools must be enforceably disabled (--tools "") so injected
+    // instructions in the document text can't make Claude Code run commands.
+    const toolsIdx = first.argv.indexOf("--tools");
+    assert.ok(toolsIdx >= 0, "must pass --tools to disable tools");
+    assert.equal(first.argv[toolsIdx + 1], "", "--tools must be empty to disable all tools");
+
+    // Privacy: no session transcript persisted to disk.
+    assert.ok(first.argv.includes("--no-session-persistence"), "must disable session persistence");
+    // Only the STATIC preamble is on argv — it carries no user-derived text.
+    const sysPromptIdx = first.argv.indexOf("--system-prompt");
+    assert.ok(sysPromptIdx >= 0, "must override --system-prompt to suppress CLAUDE.md");
+    assert.match(first.argv[sysPromptIdx + 1], /non-interactive subprocess/i);
+    assert.match(first.argv[sysPromptIdx + 1], /Disregard any guidance from CLAUDE\.md/);
+
+    // The document travels via stdin, never argv. The static preamble must NOT
+    // leak into stdin (it stays on argv as the system prompt override).
+    assert.ok(first.stdin.length > 0, "prompt + document should be delivered via stdin");
+    assert.match(first.stdin, /This generated paragraph needs a calmer rewrite\./);
+    assert.doesNotMatch(first.stdin, /non-interactive subprocess/i, "static preamble must stay on argv, not stdin");
+    // Privacy regression guard: the document must never appear on argv.
+    assert.ok(
+      !first.argv.some((a) => /This generated paragraph needs a calmer rewrite\./.test(a)),
+      "document text must NOT appear on argv",
+    );
+  });
+
+  test("humanizes via the codex CLI runner with prompt on stdin", async () => {
+    const recordPath = path.join(tmpRoot, "codex-invocations.jsonl");
+    const env = testEnv({
+      STEALTHHUMANIZER_CODEX_BIN: fakeCliRunnerPath,
+      // FAKE_CLI_MODE=codex-output writes the canned response to the path
+      // given by -o (matching how real Codex behaves) instead of stdout.
+      FAKE_CLI_MODE: "codex-output",
+      FAKE_CLI_RECORD_FILE: recordPath,
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "codex",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertSuccess(result);
+    assert.match(result.stdout, /rewritten paragraph/i);
+
+    const lines = (await fs.readFile(recordPath, "utf8")).trim().split("\n");
+    const first = JSON.parse(lines[0]);
+    // Codex argv shape: exec --skip-git-repo-check --color never --sandbox read-only
+    //   -C <dir> -c <cfg> -o <file> --model <id>   (NO positional prompt)
+    assert.equal(first.argv[0], "exec");
+    assert.ok(first.argv.includes("--skip-git-repo-check"), "must pass --skip-git-repo-check");
+    assert.ok(first.argv.includes("--color"), "must pass --color");
+    // Security: Codex must run in a read-only sandbox so untrusted document
+    // text can't make it execute shell commands or write files.
+    const sandboxIdx = first.argv.indexOf("--sandbox");
+    assert.ok(sandboxIdx >= 0, "must pass --sandbox");
+    assert.equal(first.argv[sandboxIdx + 1], "read-only", "Codex must use read-only sandbox");
+    // Confinement: working root is an isolated dir and no parent env is inherited.
+    const cdIdx = first.argv.indexOf("-C");
+    assert.ok(cdIdx >= 0 && first.argv[cdIdx + 1], "Codex must set an isolated working root with -C");
+    const cfgIdx = first.argv.indexOf("-c");
+    assert.ok(cfgIdx >= 0, "Codex must pass a -c config override");
+    assert.equal(first.argv[cfgIdx + 1], "shell_environment_policy.inherit=none", "Codex must not inherit parent env");
+    // Privacy: no session files persisted to disk.
+    assert.ok(first.argv.includes("--ephemeral"), "Codex must run ephemerally (no session persistence)");
+    const outputFlagIdx = first.argv.indexOf("-o");
+    assert.ok(outputFlagIdx >= 0, "must pass -o to capture clean output");
+    assert.ok(first.argv[outputFlagIdx + 1], "must follow -o with a path");
+    const modelFlagIdx = first.argv.indexOf("--model");
+    assert.ok(modelFlagIdx >= 0, "must pass --model");
+    assert.equal(first.argv[modelFlagIdx + 1], "gpt-5.5");
+    // Privacy: the prompt (system + user document) must travel via stdin, NOT
+    // argv — argv is visible in process listings and capped by ARG_MAX.
+    assert.ok(
+      !first.argv.some((a) => /This generated paragraph needs a calmer rewrite\./.test(a)),
+      "user document must NOT appear on argv",
+    );
+    assert.equal(first.stdinKind, "pipe", "Codex prompt must be delivered via piped stdin");
+    assert.match(first.stdin, /This generated paragraph needs a calmer rewrite\./);
+  });
+
+  test("surfaces the CLI runner's stderr when it exits non-zero", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: fakeCliRunnerPath,
+      FAKE_CLI_MODE: "fail",
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Anything.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /Claude Code exited 1/);
+    assert.match(result.stderr, /fake cli boom/);
+  });
+
+  test("reports a missing binary clearly when ENOENT occurs", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: "/nonexistent/path/to/claude",
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Anything.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /not found on PATH/);
+    assert.match(result.stderr, /STEALTHHUMANIZER_CLAUDE_CODE_BIN/);
+  });
+
+  test("missing Codex binary names the Codex override, not the Claude one", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CODEX_BIN: "/nonexistent/path/to/codex",
+    });
+
+    const result = await runCli(
+      ["humanize", "--text", "Anything.", "--model", "codex", "--quiet"],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /not found on PATH/);
+    assert.match(result.stderr, /STEALTHHUMANIZER_CODEX_BIN/);
+    assert.doesNotMatch(result.stderr, /STEALTHHUMANIZER_CLAUDE_CODE_BIN/);
+  });
+
+  test("CLI-runner provider does not require --api-key flag", async () => {
+    // Regression: ensure the cliOnly branch in resolveApiKey actually short-
+    // circuits the "Missing API key" error. We point at a nonexistent binary
+    // so the spawn fails fast, but the error must NOT be about the API key.
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: "/nonexistent/path/to/claude",
+    });
+
+    const result = await runCli(
+      ["humanize", "--text", "Anything.", "--model", "claude-code", "--quiet"],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.doesNotMatch(result.stderr, /Missing API key/);
   });
 });

--- a/scripts/tests/cli.test.mjs
+++ b/scripts/tests/cli.test.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const cliPath = path.join(repoRoot, "dist/bin/cli.js");
+const mockFetchPath = path.join(repoRoot, "scripts/tests/fixtures/mock-cli-fetch.mjs");
+const providerEnvVars = [
+  "GEMINI_API_KEY",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "COHERE_API_KEY",
+  "TOGETHER_API_KEY",
+  "OPENROUTER_API_KEY",
+  "CEREBRAS_API_KEY",
+  "DEEPINFRA_API_KEY",
+  "HUGGINGFACE_API_KEY",
+  "CLOUDFLARE_API_KEY",
+  "ZAI_API_KEY",
+];
+
+let tmpRoot;
+
+before(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "stealthhumanizer-cli-"));
+});
+
+after(async () => {
+  if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+function testEnv(extra = {}) {
+  const env = { ...process.env };
+  for (const key of providerEnvVars) delete env[key];
+
+  Object.assign(env, extra);
+  return env;
+}
+
+function withMockFetch(extra = {}) {
+  const mockImport = `--import=${pathToFileURL(mockFetchPath).href}`;
+  const priorNodeOptions = extra.NODE_OPTIONS ?? process.env.NODE_OPTIONS ?? "";
+  return testEnv({
+    ...extra,
+    NODE_OPTIONS: [priorNodeOptions, mockImport].filter(Boolean).join(" "),
+  });
+}
+
+function runCli(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: repoRoot,
+      env: options.env ?? testEnv(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (options.input !== undefined) child.stdin.end(options.input);
+    else child.stdin.end();
+  });
+}
+
+function assertSuccess(result) {
+  assert.equal(result.code, 0, result.stderr);
+}
+
+function assertFailure(result) {
+  assert.notEqual(result.code, 0, "Expected command to fail.");
+}
+
+function parseJsonOutput(result) {
+  assertSuccess(result);
+  assert.equal(result.stderr, "");
+  return JSON.parse(result.stdout);
+}
+
+describe("StealthHumanizer CLI", () => {
+  test("prints the package version", async () => {
+    const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8"));
+    const result = await runCli(["--version"]);
+
+    assertSuccess(result);
+    assert.equal(result.stdout.trim(), packageJson.version);
+    assert.equal(result.stderr, "");
+  });
+
+  test("prints top-level and command-specific help", async () => {
+    const topLevel = await runCli(["--help"]);
+    assertSuccess(topLevel);
+    assert.match(topLevel.stdout, /StealthHumanizer CLI/);
+    assert.match(topLevel.stdout, /humanize\s+Rewrite text/);
+    assert.match(topLevel.stdout, /detect\s+Score text/);
+    assert.match(topLevel.stdout, /providers\s+List supported providers/);
+
+    const detectHelp = await runCli(["help", "detect"]);
+    assertSuccess(detectHelp);
+    assert.match(detectHelp.stdout, /stealthhumanizer detect/);
+    assert.match(detectHelp.stdout, /--report/);
+    assert.doesNotMatch(detectHelp.stdout, /Humanization options/);
+  });
+
+  test("lists providers as a readable table", async () => {
+    const result = await runCli(["providers"]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Provider\s+Free\s+Env var\s+Default model\s+Name/);
+    assert.match(result.stdout, /gemini\s+yes\s+GEMINI_API_KEY\s+gemini-1\.5-flash/);
+    assert.match(result.stdout, /openai\s+no\s+OPENAI_API_KEY\s+gpt-4o/);
+    assert.equal(result.stderr, "");
+  });
+
+  test("lists providers as structured JSON", async () => {
+    const providers = parseJsonOutput(await runCli(["providers", "--json"]));
+    const gemini = providers.find((provider) => provider.id === "gemini");
+    const openai = providers.find((provider) => provider.id === "openai");
+
+    assert.ok(Array.isArray(providers));
+    assert.ok(providers.length >= 10);
+    assert.equal(gemini.env, "GEMINI_API_KEY");
+    assert.equal(gemini.free, true);
+    assert.equal(gemini.defaultModel, "gemini-1.5-flash");
+    assert.equal(openai.free, false);
+    assert.equal(Object.hasOwn(gemini, "getApiKeyUrl"), true);
+  });
+
+  test("scores text from --text with readable detector output", async () => {
+    const result = await runCli([
+      "detect",
+      "--text",
+      "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    ]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Score: \d+% human \((human|mixed|ai)\)/);
+    assert.match(result.stdout, /Metrics:/);
+    assert.match(result.stdout, /AI phrase: "it is important to note"/);
+    assert.equal(result.stderr, "");
+  });
+
+  test("scores stdin as detector JSON", async () => {
+    const result = await runCli(["detect", "--json"], {
+      input: "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    });
+    const payload = parseJsonOutput(result);
+
+    assert.equal(typeof payload.score, "number");
+    assert.equal(payload.overallVerdict, "mixed");
+    assert.equal(payload.sentences.length, 1);
+    assert.ok(payload.sentences[0].issues.some((issue) => issue.includes("it is important to note")));
+    assert.equal(typeof payload.readability.fleschKincaidGrade, "number");
+  });
+
+  test("writes detector output to a file and can include every sentence", async () => {
+    const inputPath = path.join(tmpRoot, "draft.txt");
+    const outputPath = path.join(tmpRoot, "detect-report.txt");
+    await fs.writeFile(
+      inputPath,
+      "This paper explores the multifaceted impacts of automation. Furthermore, it is important to note that adoption can optimize workflows.",
+    );
+
+    const result = await runCli(["detect", "--input", inputPath, "--output", outputPath, "--sentences"]);
+    const output = await fs.readFile(outputPath, "utf8");
+
+    assertSuccess(result);
+    assert.equal(result.stdout, "");
+    assert.match(output, /Sentences:/);
+    assert.match(output, /This paper explores the multifaceted impacts of automation/);
+    assert.match(output, /Furthermore, it is important to note/);
+  });
+
+  test("prints detailed detector report output", async () => {
+    const result = await runCli([
+      "detect",
+      "--report",
+      "--text",
+      "Furthermore, it is important to note that this solution demonstrates the potential to optimize workflows.",
+    ]);
+
+    assertSuccess(result);
+    assert.match(result.stdout, /Most AI-like sentences:/);
+    assert.match(result.stdout, /Detected AI phrases:/);
+    assert.match(result.stdout, /Recommendations:/);
+    assert.match(result.stdout, /Focus on rewriting the lowest-scoring sentence/);
+  });
+
+  test("fails cleanly for unknown options and invalid choices", async () => {
+    const unknownOption = await runCli(["detect", "--bogus"]);
+    assertFailure(unknownOption);
+    assert.match(unknownOption.stderr, /Unknown option: --bogus/);
+    assert.match(unknownOption.stderr, /Run "stealthhumanizer --help"/);
+
+    const invalidProvider = await runCli([
+      "humanize",
+      "--text",
+      "hello",
+      "--api-key",
+      "fake-key",
+      "--model",
+      "notaprovider",
+    ]);
+    assertFailure(invalidProvider);
+    assert.match(invalidProvider.stderr, /Invalid --model: notaprovider/);
+    assert.doesNotMatch(invalidProvider.stderr, /API key/);
+
+    const invalidTarget = await runCli([
+      "humanize",
+      "--text",
+      "hello",
+      "--model",
+      "gemini",
+      "--api-key",
+      "fake-key",
+      "--target",
+      "150",
+    ]);
+    assertFailure(invalidTarget);
+    assert.match(invalidTarget.stderr, /Invalid --target: 150/);
+  });
+
+  test("fails before network calls when humanize has no API key", async () => {
+    const result = await runCli(["humanize", "--text", "hello", "--model", "gemini"]);
+
+    assertFailure(result);
+    assert.match(result.stderr, /Missing API key for gemini/);
+    assert.match(result.stderr, /GEMINI_API_KEY/);
+    assert.equal(result.stdout, "");
+  });
+
+  test("humanizes text with mocked provider fetch and writes plain output", async () => {
+    const outputPath = path.join(tmpRoot, "humanized.txt");
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "gemini",
+        "--api-key",
+        "fake-key",
+        "--output",
+        outputPath,
+        "--quiet",
+      ],
+      { env: withMockFetch() },
+    );
+    const output = await fs.readFile(outputPath, "utf8");
+
+    assertSuccess(result);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+    assert.match(output, /rewritten paragraph/i);
+    assert.match(output, /meaning intact/i);
+  });
+
+  test("humanizes text as JSON and preserves option mapping", async () => {
+    const styleGuidePath = path.join(tmpRoot, "style-guide.txt");
+    await fs.writeFile(styleGuidePath, "Use plain, direct language with short paragraphs.");
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Please rewrite this while preserving the link https://example.com.",
+        "--model",
+        "gemini",
+        "--api-key-env",
+        "CUSTOM_GEMINI_KEY",
+        "--json",
+        "--quiet",
+        "--style",
+        "academic",
+        "--level",
+        "light",
+        "--language",
+        "en-US",
+        "--domain",
+        "Computer Science",
+        "--target",
+        "77",
+        "--style-guide",
+        styleGuidePath,
+        "--no-aggressive-synonyms",
+      ],
+      { env: withMockFetch({ CUSTOM_GEMINI_KEY: "fake-key" }) },
+    );
+    const payload = parseJsonOutput(result);
+
+    assert.match(payload.fullText, /rewritten paragraph/i);
+    assert.match(payload.fullText, /https:\/\/example\.com/);
+    assert.equal(payload.model, "gemini");
+    assert.equal(payload.options.style, "academic");
+    assert.equal(payload.options.level, "light");
+    assert.equal(payload.options.language, "en-US");
+    assert.equal(payload.options.domain, "Computer Science");
+    assert.equal(payload.options.targetScore, 77);
+    assert.equal(payload.options.tone, "custom");
+    assert.equal(payload.options.customTone, "Use plain, direct language with short paragraphs.");
+    assert.equal(payload.options.aggressiveSynonyms, false);
+  });
+});

--- a/scripts/tests/fixtures/fake-cli-runner.mjs
+++ b/scripts/tests/fixtures/fake-cli-runner.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Fake Claude Code / Codex binary used by cli.test.mjs to exercise the
+// subprocess provider path without requiring the real CLIs to be installed.
+//
+// Behavior is controlled by env vars set by the test:
+//   FAKE_CLI_MODE=success       — emit a canned humanized paragraph on stdout
+//   FAKE_CLI_MODE=codex-output  — write the canned reply to the path given by
+//                                  -o <file> (mimics real Codex), plus some
+//                                  banner-ish noise on stdout
+//   FAKE_CLI_MODE=formatted      — emit a markdown-ish technical response with
+//                                  blank lines and protected tokens
+//   FAKE_CLI_MODE=fail          — write to stderr and exit 1
+//   FAKE_CLI_MODE=echo-args     — emit the argv as JSON (for arg assertions)
+//   FAKE_CLI_RECORD_FILE=<path> — append a JSON line per invocation with
+//                                  { argv, stdin, stdinKind } for the test
+//                                  to inspect
+
+import { readFileSync, appendFileSync, writeFileSync, fstatSync } from "node:fs";
+
+const mode = process.env.FAKE_CLI_MODE ?? "success";
+const record = process.env.FAKE_CLI_RECORD_FILE;
+
+function readStdinSync() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function classifyStdin() {
+  try {
+    const stat = fstatSync(0);
+    // Node's child_process.spawn uses Unix domain socket pairs (not POSIX
+    // FIFOs) on macOS for stdio: 'pipe'. On Linux it uses pipes. Treat both
+    // as "pipe" — the semantic we care about is "data can flow in".
+    if (stat.isFIFO() || stat.isSocket()) return "pipe";
+    if (stat.isCharacterDevice()) {
+      return process.stdin.isTTY ? "tty" : "char";
+    }
+    if (stat.isFile()) return "file";
+    return "other";
+  } catch {
+    return "closed";
+  }
+}
+
+const stdinKind = classifyStdin();
+// Only attempt to read stdin if it's a pipe — reading from /dev/null is
+// harmless but makes the test's intent ambiguous.
+const stdin = stdinKind === "pipe" ? readStdinSync() : "";
+const argv = process.argv.slice(2);
+
+if (record) {
+  appendFileSync(
+    record,
+    JSON.stringify({ argv, stdin, stdinKind }) + "\n",
+    "utf8",
+  );
+}
+
+const CANNED_REPLY =
+  "This rewritten paragraph keeps its meaning intact. It reads naturally now.";
+const FORMATTED_TECHNICAL_REPLY = `Verifier 0: binary integrity.
+
+Before running anything, hash \`validator\` and \`bin/linux-x86_64/license_validator\`.
+
+Reference hash: \`75d494fe14ad865b15a392c4d2317755a0ab771916ef53b78331d593cfc66193\`.
+Version: Zig 0.15.2.`;
+
+if (mode === "fail") {
+  process.stderr.write("fake cli boom\n");
+  process.exit(1);
+}
+
+if (mode === "echo-args") {
+  process.stdout.write(JSON.stringify({ argv, stdin, stdinKind }));
+  process.exit(0);
+}
+
+if (mode === "codex-output") {
+  // Mimic Codex's `-o <file>` behavior: write the reply to the file argument
+  // and put banner-ish noise on stdout (which the adapter should ignore).
+  const outputFlagIdx = argv.indexOf("-o");
+  if (outputFlagIdx === -1 || !argv[outputFlagIdx + 1]) {
+    process.stderr.write("fake codex requires -o <file>\n");
+    process.exit(1);
+  }
+  writeFileSync(argv[outputFlagIdx + 1], CANNED_REPLY + "\n", "utf8");
+  process.stdout.write("[fake codex banner: would print logs here]\n");
+  process.exit(0);
+}
+
+if (mode === "formatted") {
+  process.stdout.write(FORMATTED_TECHNICAL_REPLY + "\n");
+  process.exit(0);
+}
+
+// default ("success"): emit a canned, on-brand humanized paragraph
+process.stdout.write(CANNED_REPLY + "\n");

--- a/scripts/tests/fixtures/mock-cli-fetch.mjs
+++ b/scripts/tests/fixtures/mock-cli-fetch.mjs
@@ -1,0 +1,39 @@
+const jsonResponse = (body, init = {}) =>
+  new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+
+globalThis.fetch = async (url, init = {}) => {
+  const href = String(url);
+
+  if (href.includes("corpus-style-model.json")) {
+    return new Response("not found", { status: 404 });
+  }
+
+  if (href.includes("generativelanguage.googleapis.com")) {
+    const body = typeof init.body === "string" ? JSON.parse(init.body) : {};
+    const prompt = body?.contents?.[0]?.parts?.[0]?.text || "";
+
+    return jsonResponse({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: prompt.includes("__PROTECT_")
+                  ? "This rewritten paragraph keeps __PROTECT_0__ intact. It reads naturally now."
+                  : "This rewritten paragraph keeps its meaning intact. It reads naturally now.",
+              },
+            ],
+          },
+        },
+      ],
+    });
+  }
+
+  return jsonResponse(
+    { error: { message: `Unexpected mocked fetch URL: ${href}` } },
+    { status: 500 },
+  );
+};

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": false,
+    "noEmitOnError": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["bin/cli.ts"]
+}


### PR DESCRIPTION
Step 3 of #110 — the follow-up integration branch built on top of #109.

> [!IMPORTANT]
> **Stacked on #109. Merge #109 first, then this.** Until #109 lands on `master`, this PR's diff also shows #109's commits; once #109 is merged GitHub auto-recomputes and the diff reduces to the two commits here (`feat(providers)` + `test(cli)`). Kept as a draft until then.

## Summary

Adds two `cliOnly` providers that humanize by spawning a local CLI you're already logged into — no API key:

- **`--model claude-code`** spawns your local `claude` CLI (Claude Code)
- **`--model codex`** spawns your local `codex` CLI (OpenAI Codex)

This is the integration #110 described: it lets local users point StealthHumanizer at their own Claude Code / Codex instances.

## Architecture

`lib/providers.ts` stays browser-safe (it's imported by `Settings.tsx`), so it cannot spawn subprocesses. The integration introduces a server-only seam:

- **`lib/server/cli-providers.ts`** — the subprocess adapters. Documents two real invocation quirks: Claude Code reads the user prompt from stdin with the system prompt on argv (and forces `--permission-mode default` + a `--system-prompt` override so the subprocess ignores the operator's CLAUDE.md/plan-mode); Codex takes the prompt on argv with stdin routed to `/dev/null` so it doesn't append a `<stdin>` block and exit 1, capturing clean output via `-o <file>`.
- **`lib/server/providers-runtime.ts`** — server-only wrapper around `lib/providers`' `generateWithProvider` that intercepts the two CLI providers and delegates all HTTP providers unchanged. Every server caller (`lib/humanizer`, `lib/chain`, and the 5 `app/api/*` routes) now imports `generateWithProvider` from here.
- **`bin/cli.ts`** — `cliOnly` providers skip the API-key requirement, render as `(cli)` in the `providers` table, and report `env: null` in `--json`.

Binary paths are overridable via `STEALTHHUMANIZER_CLAUDE_CODE_BIN` / `STEALTHHUMANIZER_CODEX_BIN`.

## Scope note

This branch's source also contained a separate humanizer "editorial quality model" refactor (`lib/rewrite-guard.ts`, prompt/postprocess rewrites, `preserveStructure`/`--flexible-structure`). That is **deliberately excluded** here to keep this PR to the CLI-runner integration only — it can land as its own PR later.

## Verification

- `npm run test:cli` → **17/17 pass** (12 existing + 5 new CLI-runner tests driving a fake binary that records argv/stdin)
- `npm run build` (next build) → clean TypeScript + compile; server-only boundary holds (no `node:child_process` in the browser bundle)
- `eslint` on changed files → 0 errors

## Test plan

- [ ] Merge #109 first; confirm this PR's diff reduces to 2 commits
- [ ] CI green
- [ ] With a real `claude` login: `stealthhumanizer humanize --model claude-code --text "..."` returns rewritten text
- [ ] `stealthhumanizer providers` shows `claude-code`/`codex` as `(cli)`