### PR TITLE
feat(cli): Claude Code & Codex local CLI-runner providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ Useful commands:
 
 Run `npm run cli -- --help` for the full option list.
 
+### Local CLI-runner providers (no API key)
+
+Two providers run a local CLI you already have logged in, as a subprocess,
+instead of calling an HTTP API. They use the binary's own auth, so no API key
+is required:
+
+```bash
+# Uses your local Claude Code login
+stealthhumanizer humanize --model claude-code -i draft.txt
+
+# Uses your local OpenAI Codex login
+echo "Draft text..." | stealthhumanizer humanize --model codex
+```
+
+- `--model claude-code` spawns your local `claude` CLI (Claude Code)
+- `--model codex` spawns your local `codex` CLI (OpenAI Codex)
+- Point at a non-default binary with `STEALTHHUMANIZER_CLAUDE_CODE_BIN` or
+  `STEALTHHUMANIZER_CODEX_BIN`
+- CLI-only: these are skipped by auto-selection and are not available in the
+  browser or serverless runtimes (they spawn a subprocess). The web API rejects
+  them (including in model chains) so a browser user can't make a self-hosted
+  server spawn its logged-in CLI.
+
+**Security note — untrusted input.** The text being humanized is treated as
+untrusted (it can contain prompt-injection). The runners are confined so an
+injected instruction can't make the agent act:
+
+- `claude-code` runs with `--tools ""`, which fully disables all tools — it
+  cannot read/write files or run commands. Preferred for untrusted input.
+- `codex` has no "disable all tools" switch, so it is confined as tightly as
+  the platform allows: `--sandbox read-only` (no writes/network), an isolated
+  empty working directory, and no inherited environment. A determined injection
+  could still read absolute paths via a read-only command, so prefer
+  `claude-code` when the input is fully untrusted.
+
 Run `npm run test:cli` to build the packaged CLI entry point and execute the
 CLI regression suite.
 

--- a/app/api/alternative/route.ts
+++ b/app/api/alternative/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { generateWithProvider, generateAlternatives } from '@/lib/providers';
+import { generateAlternatives } from '@/lib/server/providers-runtime';
+import { isCliOnlyProvider } from '@/lib/providers';
 import { getSystemPrompt } from '@/lib/prompts';
 
 export async function POST(request: NextRequest) {
   try {
     const { original, current, level, style, tone, customTone, model, apiKey } = await request.json();
     if (!original || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing fields' }, { status: 400 });
+    if (isCliOnlyProvider(model)) return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
 
     const systemPrompt = getSystemPrompt(level, style, tone, customTone);
     const alternatives = await generateAlternatives(model, apiKey, original, current, systemPrompt, 3);

--- a/app/api/grammar/route.ts
+++ b/app/api/grammar/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ModelProvider } from '@/lib/types';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { GRAMMAR_CHECK_SYSTEM_PROMPT } from '@/lib/prompts';
 
 export async function POST(request: NextRequest) {
   try {
     const { text, model, apiKey } = await request.json();
     if (!text || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    if (isCliOnlyProvider(model)) return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
 
     const providerInfo = getProvider(model);
     const modelId = providerInfo?.defaultModel || model;

--- a/app/api/humanize-batch/route.ts
+++ b/app/api/humanize-batch/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { detectAI } from '@/lib/detector';
 import { postprocess } from '@/lib/postprocess';
 import { getSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
-import { generateWithProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
+import { isCliOnlyProvider } from '@/lib/providers';
 import { RewriteLevel } from '@/lib/types';
 import { asyncMapConcurrent } from '@/lib/batch';
 import { checkRateLimit } from '@/lib/rate-limit';
@@ -27,6 +28,9 @@ export async function POST(request: NextRequest) {
 
     if (!model || !apiKey) {
       return NextResponse.json({ success: false, error: 'Missing required fields: model and apiKey' }, { status: 400 });
+    }
+    if (isCliOnlyProvider(model)) {
+      return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     }
 
     if (!Array.isArray(texts) || texts.length === 0) {

--- a/app/api/humanize/route.ts
+++ b/app/api/humanize/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { RewriteLevel, StylePreset, TonePreset, ModelProvider } from '@/lib/types';
-import { getSystemPrompt, getRehumanizePrompt, getSelfCheckPrompt, getFixPrompt, getCorpusAwareSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { RewriteLevel, StylePreset, ModelProvider } from '@/lib/types';
+import { getSystemPrompt, getSelfCheckPrompt, getCorpusAwareSystemPrompt, LEVEL_PARAMS } from '@/lib/prompts';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { detectAI } from '@/lib/detector';
 import { postprocess, corpusAwarePostprocess } from '@/lib/postprocess';
 import { loadStyleModelAsync, loadStyleModel, hasStyleModel } from '@/lib/style-model';
@@ -76,6 +77,12 @@ export async function POST(request: NextRequest) {
     } = await request.json();
 
     if (!text || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    // Reject CLI-only runners on the primary model AND anywhere in the chain —
+    // chainModels flows through lib/chain into the CLI-capable runtime, so an
+    // unguarded chain entry would otherwise spawn the server's local CLI.
+    const cliOnlyRequested = [model, ...(Array.isArray(chainModelIds) ? chainModelIds : [])]
+      .find((id) => isCliOnlyProvider(id as ModelProvider));
+    if (cliOnlyRequested) return NextResponse.json({ success: false, error: `Provider "${cliOnlyRequested}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     if (countWords(text) > 10000) return NextResponse.json({ success: false, error: 'Exceeds 10,000 word limit' }, { status: 400 });
     if (Array.isArray(batchTexts) && batchTexts.length > MAX_BATCH_SIZE) {
       return NextResponse.json({ success: false, error: `Batch size exceeds limit (${MAX_BATCH_SIZE}).` }, { status: 400 });

--- a/app/api/rehumanize/route.ts
+++ b/app/api/rehumanize/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { RewriteLevel, StylePreset, TonePreset, ModelProvider } from '@/lib/types';
 import { getRehumanizePrompt } from '@/lib/prompts';
-import { generateWithProvider, getProvider } from '@/lib/providers';
+import { getProvider, isCliOnlyProvider } from '@/lib/providers';
+import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { postprocess } from '@/lib/postprocess';
 
 export async function POST(request: NextRequest) {
@@ -9,6 +9,9 @@ export async function POST(request: NextRequest) {
     const { flaggedSentences, level, style, tone, customTone, model, apiKey, fullText, purpose } = await request.json();
     if (!flaggedSentences?.length || !model || !apiKey) {
       return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    }
+    if (isCliOnlyProvider(model)) {
+      return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     }
 
     const providerInfo = getProvider(model);

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -52,6 +52,9 @@ const API_KEY_ENV: Record<ModelProvider, string> = {
   huggingface: 'HUGGINGFACE_API_KEY',
   cloudflare: 'CLOUDFLARE_API_KEY',
   zai: 'ZAI_API_KEY',
+  // CLI-runner providers handle auth via their own login state — no env var.
+  'claude-code': '',
+  codex: '',
 };
 
 const VALUE_FLAGS = new Set([
@@ -294,6 +297,11 @@ function resolveProvider(parsed: ParsedCli): ModelProvider {
 }
 
 function resolveApiKey(parsed: ParsedCli, provider: ModelProvider): string {
+  // CLI-runner providers authenticate via their own subprocess login, so
+  // there's no API key to resolve. Returning '' satisfies the downstream
+  // signature; the adapter ignores it.
+  if (getProvider(provider)?.cliOnly) return '';
+
   const explicitApiKey = flagString(parsed, 'api-key');
   if (explicitApiKey) return explicitApiKey;
 
@@ -415,9 +423,10 @@ function formatProvidersJson(): string {
     id: provider.id,
     name: provider.name,
     free: provider.free,
+    cliOnly: provider.cliOnly === true,
     defaultModel: provider.defaultModel,
     models: provider.models,
-    env: API_KEY_ENV[provider.id],
+    env: provider.cliOnly ? null : API_KEY_ENV[provider.id],
     getApiKeyUrl: provider.getApiKeyUrl,
     docsUrl: provider.docsUrl,
   }));
@@ -432,7 +441,7 @@ function formatProvidersTable(): string {
   const rows = PROVIDERS.map((provider) => ({
     provider: provider.id,
     free: provider.free ? 'yes' : 'no',
-    env: API_KEY_ENV[provider.id],
+    env: provider.cliOnly ? '(cli)' : API_KEY_ENV[provider.id],
     defaultModel: provider.defaultModel,
     name: provider.name,
   }));
@@ -517,6 +526,11 @@ Humanization options:
 API keys:
   --api-key <key>           Pass an API key directly
   --api-key-env <name>      Read the API key from a custom environment variable
+
+CLI-runner providers (no API key needed):
+  --model claude-code       Spawns your local "claude" CLI (Claude Code)
+  --model codex             Spawns your local "codex" CLI (OpenAI Codex)
+  Overrides: STEALTHHUMANIZER_CLAUDE_CODE_BIN, STEALTHHUMANIZER_CODEX_BIN
 
 Run "stealthhumanizer providers" to see provider ids and default env vars.`;
 }

--- a/components/BatchHumanizer.tsx
+++ b/components/BatchHumanizer.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Layers, Plus, Trash2, Zap, Copy, AlertTriangle, CheckCircle, Loader2 } from 'lucide-react';
 import { getApiKeys } from '@/lib/storage';
-import { PROVIDERS } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS } from '@/lib/providers';
 import { ModelProvider } from '@/lib/types';
 
 interface BatchItem {

--- a/components/Humanizer.tsx
+++ b/components/Humanizer.tsx
@@ -12,7 +12,7 @@ import { TONE_CONFIGS, SAMPLE_AI_TEXT, SAMPLE_TECHNICAL_TEXT, PURPOSE_CONFIGS } 
 import { detectAI, getScoreColor, getScoreBarColor } from '@/lib/detector';
 import { getReadabilityLabel } from '@/lib/readability';
 import { countWords, downloadAsTxt, downloadAsDocx, downloadAsMarkdown, getApiKeys } from '@/lib/storage';
-import { PROVIDERS } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS } from '@/lib/providers';
 import dynamic from 'next/dynamic';
 
 const ComparisonChart = dynamic(

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Settings as SettingsIcon, Key, Eye, EyeOff, ExternalLink, Shield, Check, X, Zap, Star, RotateCcw } from 'lucide-react';
-import { PROVIDERS, getProvider, testApiKey } from '@/lib/providers';
+import { WEB_PROVIDERS as PROVIDERS, getProvider, testApiKey } from '@/lib/providers';
 import { getApiKeys, setApiKeys, clearApiKeys } from '@/lib/storage';
 import { ModelProvider } from '@/lib/types';
 

--- a/lib/chain.ts
+++ b/lib/chain.ts
@@ -2,7 +2,8 @@
 // Chain rewrites through different LLM models to mix statistical fingerprints.
 
 import { ModelProvider } from './types';
-import { generateWithProvider, getProvider } from './providers';
+import { getProvider } from './providers';
+import { generateWithProvider } from './server/providers-runtime';
 import { getSystemPrompt } from './prompts';
 import { postprocess } from './postprocess';
 

--- a/lib/humanizer.ts
+++ b/lib/humanizer.ts
@@ -3,7 +3,8 @@
 import { HumanizationOptions, HumanizationResult, SentenceResult } from './types';
 import { getSystemPrompt, getRehumanizePrompt, getCorpusAwareSystemPrompt } from './prompts';
 import { getCorpusCalibratedThresholds, hasStyleModel, loadStyleModelAsync } from './style-model';
-import { generateWithProvider, getProvider, generateAlternatives } from './providers';
+import { getProvider } from './providers';
+import { generateWithProvider, generateAlternatives } from './server/providers-runtime';
 import { detectAI } from './detector';
 import { postprocess, corpusAwarePostprocess } from './postprocess';
 import { chunkText, countWords, addToHistory } from './storage';

--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -1,7 +1,17 @@
 // Unified Provider Interface for all AI providers
 // StealthHumanizer v2 - Free AI Text Humanizer
+//
+// Browser-safe: this file is imported by client components (Settings.tsx)
+// because they need PROVIDERS metadata and call testApiKey() from the browser
+// (API keys go straight from the browser to the provider — no server proxy).
+// Therefore NO node: builtins or subprocess imports here. CLI-runner providers
+// (claude-code, codex) cannot execute through this file — call sites in
+// server-only contexts must use lib/server/providers-runtime instead, which
+// wraps this file's generateWithProvider and intercepts the CLI cases.
 
 import { ModelProvider, Provider } from './types';
+
+export type { ModelProvider, Provider };
 
 // ==================== FETCH WITH TIMEOUT + RETRY ====================
 
@@ -224,7 +234,42 @@ export const PROVIDERS: Provider[] = [
     ],
     placeholder: '...',
   },
+  {
+    id: 'claude-code',
+    name: 'Claude Code (CLI)',
+    description: 'Runs your local Claude Code CLI as a subprocess. Uses your existing Claude subscription — no API key required. CLI/Node only.',
+    free: true,
+    cliOnly: true,
+    apiUrl: '',
+    getApiKeyUrl: 'https://docs.claude.com/en/docs/claude-code/overview',
+    docsUrl: 'https://docs.claude.com/en/docs/claude-code/cli-reference',
+    // 'opus' / 'sonnet' / 'haiku' are aliases the claude CLI resolves to the
+    // latest version in each family (currently Opus 4.7, Sonnet 4.6, Haiku 4.5).
+    // Prefer aliases so this default stays correct as Anthropic ships new
+    // versions without requiring a registry bump.
+    defaultModel: 'opus',
+    models: ['opus', 'sonnet', 'haiku', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    placeholder: '',
+  },
+  {
+    id: 'codex',
+    name: 'OpenAI Codex (CLI)',
+    description: 'Runs your local Codex CLI as a subprocess. Uses your existing OpenAI subscription — no API key required. CLI/Node only.',
+    free: true,
+    cliOnly: true,
+    apiUrl: '',
+    getApiKeyUrl: 'https://github.com/openai/codex',
+    docsUrl: 'https://github.com/openai/codex#readme',
+    defaultModel: 'gpt-5.5',
+    models: ['gpt-5.5', 'gpt-5-codex', 'gpt-5', 'o4-mini'],
+    placeholder: '',
+  },
 ];
+
+// Providers safe to surface in the browser UI. CLI-only runners are excluded:
+// they spawn a local subprocess on the server, so they must never be selectable
+// from the web client (the API routes also reject them — see isCliOnlyProvider).
+export const WEB_PROVIDERS: Provider[] = PROVIDERS.filter((p) => !p.cliOnly);
 
 // ==================== PROVIDER FUNCTIONS ====================
 
@@ -233,17 +278,23 @@ export function getProvider(id: ModelProvider): Provider | undefined {
 }
 
 export function getAvailableProvider(keys: Record<string, string | undefined>): ModelProvider | null {
-  // Priority order for free providers
+  // Priority order for free providers. CLI-only runners (claude-code, codex)
+  // are intentionally omitted — they require a local binary and explicit
+  // --model selection, so we never auto-select them.
   const priority: ModelProvider[] = [
     'gemini', 'groq', 'openrouter', 'together', 'cerebras', 'zai',
     'mistral', 'cohere', 'deepinfra', 'huggingface', 'cloudflare',
     'openai', 'claude'
   ];
-  
+
   for (const provider of priority) {
     if (keys[provider]) return provider;
   }
   return null;
+}
+
+export function isCliOnlyProvider(id: ModelProvider): boolean {
+  return getProvider(id)?.cliOnly === true;
 }
 
 export function getProviderDisplayName(provider: ModelProvider): string {
@@ -306,7 +357,7 @@ async function geminiGenerate(
   options: GenerationOptions = {}
 ): Promise<string> {
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-  
+
   const response = await fetchWithRetry(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -374,7 +425,7 @@ async function huggingfaceGenerate(
   options: GenerationOptions = {}
 ): Promise<string> {
   const url = `https://api-inference.huggingface.co/models/${model}`;
-  
+
   const response = await fetchWithRetry(url, {
     method: 'POST',
     headers: {
@@ -431,11 +482,15 @@ async function claudeGenerate(
   }
 
   const data = await response.json();
-  const textBlock = data.content?.find((b: any) => b.type === 'text');
+  const textBlock = data.content?.find((b: { type?: string; text?: string }) => b.type === 'text');
   return textBlock?.text || '';
 }
 
 // ==================== MAIN GENERATION FUNCTION ====================
+
+const CLI_RUNTIME_REQUIRED_MESSAGE =
+  'CLI-runner providers (claude-code, codex) require the server runtime. ' +
+  'Import generateWithProvider from "@/lib/server/providers-runtime" in server-only code.';
 
 export async function generateWithProvider(
   provider: ModelProvider,
@@ -455,72 +510,77 @@ export async function generateWithProvider(
   switch (provider) {
     case 'gemini':
       return geminiGenerate(apiKey, systemPrompt, userPrompt, model, options);
-    
+
     case 'claude':
       return claudeGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'cohere':
       return cohereGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'huggingface':
       return huggingfaceGenerate(apiKey, systemPrompt, fullUserPrompt, model, options);
-    
+
     case 'openai':
       return openAICompatibleGenerate(
         'https://api.openai.com/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'groq':
       return openAICompatibleGenerate(
         'https://api.groq.com/openai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'mistral':
       return openAICompatibleGenerate(
         'https://api.mistral.ai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'together':
       return openAICompatibleGenerate(
         'https://api.together.xyz/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'openrouter':
       return openAICompatibleGenerate(
         'https://openrouter.ai/api/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'cerebras':
       return openAICompatibleGenerate(
         'https://api.cerebras.ai/v1/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
     case 'deepinfra':
       return openAICompatibleGenerate(
         'https://api.deepinfra.com/v1/openai/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
-    case 'cloudflare':
+
+    case 'cloudflare': {
       const accountId = apiKey.split(':')[0];
       const apiToken = apiKey.split(':')[1] || apiKey;
       return openAICompatibleGenerate(
         `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`,
         apiToken, systemPrompt, fullUserPrompt, model, options
       );
-    
+    }
+
     case 'zai':
       return openAICompatibleGenerate(
         'https://api.z.ai/api/paas/v4/chat/completions',
         apiKey, systemPrompt, fullUserPrompt, model, options
       );
-    
+
+    case 'claude-code':
+    case 'codex':
+      throw new Error(CLI_RUNTIME_REQUIRED_MESSAGE);
+
     default:
       throw new Error(`Provider ${provider} not implemented`);
   }
@@ -546,7 +606,7 @@ Provide ${count} DIFFERENT alternative humanizations of the original sentence. M
 Return ONLY the ${count} alternative sentences, one per line. No numbering, no explanations.`;
 
   const result = await generateWithProvider(provider, apiKey, altPrompt, '', { temperature: 1.0, maxTokens: 1024 });
-  
+
   return result
     .split('\n')
     .map(line => line.replace(/^[\d\-\*\.]+\s*/, '').trim())
@@ -557,16 +617,13 @@ Return ONLY the ${count} alternative sentences, one per line. No numbering, no e
 // ==================== TEST API KEY ====================
 
 export async function testApiKey(provider: ModelProvider, apiKey: string): Promise<boolean> {
-  if (!apiKey || !apiKey.trim()) {
-    return false;
-  }
-  
+  // CLI-runner providers don't have API keys to test from the browser. The
+  // server-side equivalent is testCliProvider() in lib/server/providers-runtime.
+  if (isCliOnlyProvider(provider)) return false;
   try {
-    await generateWithProvider(provider, apiKey.trim(), 'You are a test assistant.', 'Say "ok" and nothing else.', { maxTokens: 10 });
+    await generateWithProvider(provider, apiKey, 'You are a test assistant.', 'Say "ok" and nothing else.', { maxTokens: 10 });
     return true;
-  } catch (error) {
-    // Log error for debugging but return false for invalid key
-    console.error(`API key test failed for ${provider}:`, error);
+  } catch {
     return false;
   }
 }

--- a/lib/server/cli-providers.ts
+++ b/lib/server/cli-providers.ts
@@ -1,0 +1,286 @@
+// CLI-runner adapters: spawn Claude Code / Codex as a subprocess instead of
+// hitting an HTTP API. They use the user's existing CLI login, so no API key
+// is required. Server-only — lives under lib/server/ which Next.js treats as
+// server-only by convention (see lib/server/humanization-governance.ts).
+//
+// Two known invocation quirks live here:
+//
+//  1. Claude Code (`claude -p`): reads prompt from stdin when no positional
+//     is given. Use stdin to avoid ARG_MAX risk on long humanization chunks.
+//
+//  2. Codex (`codex exec`): the prompt is piped via stdin as the sole input
+//     (no argv positional) — keeping the user's private document off the
+//     command line / process listings and clear of ARG_MAX. Codex's `<stdin>`
+//     block bug only fires when a positional prompt AND piped stdin are both
+//     supplied, so stdin-only is safe. Output extraction uses `-o <file>` to
+//     get just the assistant's final message instead of parsing the
+//     banner-plus-echo cruft Codex writes to stdout.
+
+import { spawn, type SpawnOptions, type StdioOptions } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const STDERR_TAIL_LIMIT = 2_000;
+
+interface CliRunnerOptions {
+  model?: string;
+  timeoutMs?: number;
+}
+
+interface PreparedInvocation {
+  args: string[];
+  /** Content to write to stdin when stdinMode='pipe'. Defaults to the system+
+   *  user prompts joined with two newlines. Override when the adapter already
+   *  threads the system prompt through argv (e.g. Claude Code's
+   *  `--system-prompt` flag) and only the user content should go to stdin. */
+  stdinContent?: string;
+  /** Called after the child exits cleanly (code 0). If present, its return
+   *  value replaces the captured stdout as the function's result. Useful when
+   *  the CLI writes its real output to a file (e.g. Codex's `-o` flag). */
+  finalize?: (stdout: string) => Promise<string>;
+  /** Always called after the child exits (success or failure) for cleanup. */
+  cleanup?: () => Promise<void>;
+}
+
+interface CliRunnerConfig {
+  label: string;
+  /** Env var that overrides the binary path, surfaced in the ENOENT message
+   *  so users are pointed at the correct provider-specific override. */
+  overrideEnvVar: string;
+  bin: string;
+  /** Builds argv + optional finalize/cleanup hooks. Async so adapters can
+   *  prepare temp files before spawning. */
+  prepare(systemPrompt: string, userPrompt: string, options: CliRunnerOptions): Promise<PreparedInvocation>;
+  /** When 'pipe', the combined prompt is written to stdin and stdin is closed.
+   *  When 'ignore', stdin is set to /dev/null so the child can't read from it
+   *  at all (matters for tools like Codex that auto-detect piped stdin). */
+  stdinMode: 'pipe' | 'ignore';
+}
+
+function resolveBin(envVar: string, fallback: string): string {
+  const override = process.env[envVar];
+  return override && override.trim().length > 0 ? override : fallback;
+}
+
+function combinePrompts(systemPrompt: string, userPrompt: string): string {
+  return systemPrompt ? `${systemPrompt}\n\n${userPrompt}` : userPrompt;
+}
+
+function tailStderr(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length <= STDERR_TAIL_LIMIT) return trimmed;
+  return `...${trimmed.slice(-STDERR_TAIL_LIMIT)}`;
+}
+
+async function runCli(
+  config: CliRunnerConfig,
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions,
+): Promise<string> {
+  const combined = combinePrompts(systemPrompt, userPrompt);
+  const prepared = await config.prepare(systemPrompt, userPrompt, options);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const stdio: StdioOptions = [config.stdinMode, 'pipe', 'pipe'];
+  const spawnOptions: SpawnOptions = { stdio, env: process.env };
+
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      const child = spawn(config.bin, prepared.args, spawnOptions);
+
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let settled = false;
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        settle(() => reject(new Error(`${config.label} timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdoutBuf += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderrBuf += chunk.toString('utf8');
+      });
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          settle(() =>
+            reject(
+              new Error(
+                `${config.label} binary "${config.bin}" not found on PATH. ` +
+                  `Install it, or set ${config.overrideEnvVar} to its path.`,
+              ),
+            ),
+          );
+          return;
+        }
+        settle(() => reject(err));
+      });
+
+      // Resolve on 'close', not 'exit': 'exit' can fire before the stdout/stderr
+      // pipes have flushed, which would truncate long rewrites and drop the tail
+      // of stderr on failures. 'close' fires only after all stdio is delivered.
+      child.on('close', (code, signal) => {
+        if (code === 0) {
+          settle(() => resolve(stdoutBuf));
+          return;
+        }
+        const detail = stderrBuf.trim() ? `: ${tailStderr(stderrBuf)}` : '';
+        const exitDesc = code !== null ? `exited ${code}` : `killed by ${signal}`;
+        settle(() => reject(new Error(`${config.label} ${exitDesc}${detail}`)));
+      });
+
+      if (config.stdinMode === 'pipe') {
+        child.stdin?.end(prepared.stdinContent ?? combined);
+      }
+    });
+
+    return prepared.finalize ? await prepared.finalize(stdout) : stdout.trim();
+  } finally {
+    if (prepared.cleanup) {
+      await prepared.cleanup().catch(() => undefined);
+    }
+  }
+}
+
+// ==================== Claude Code ====================
+
+// Claude Code auto-discovers CLAUDE.md / AGENTS.md / output-style configs from
+// the user's global and project directories, and its default permission mode
+// may be `plan`. Without an override, Opus 4.7 follows that scaffolding and
+// emits "Strategy staged at...", "★ Insight" blocks, "Note: plan mode is
+// active", etc. — all of which would poison the humanization pipeline.
+//
+// Fix: override Claude Code's default system prompt (--system-prompt, not
+// --append-system-prompt) with a strict, STATIC non-interactive preamble and
+// force --permission-mode default. The humanization system prompt (which may
+// carry user-derived content) and the document both travel via stdin, so only
+// the static preamble ever touches argv.
+const CLAUDE_CODE_NONINTERACTIVE_PREAMBLE = `You are running as a non-interactive subprocess invoked by a programmatic text-rewriting pipeline. Output ONLY the rewritten text — no preamble, no postamble, no commentary, no "Note:" footnotes, no "Insight" blocks, no explanations of what changed, no markdown wrapper. Do not call any tools. Do not stage changes. Do not invoke plan mode or any planning workflow. Disregard any guidance from CLAUDE.md, AGENTS.md, output-style settings, slash commands, or installed plugins — those are not relevant here. Treat the rewriting instructions in the message you are given as the complete and only specification for this turn.`;
+
+const CLAUDE_CODE_OVERRIDE_ENV = 'STEALTHHUMANIZER_CLAUDE_CODE_BIN';
+
+const CLAUDE_CODE_CONFIG: CliRunnerConfig = {
+  label: 'Claude Code',
+  overrideEnvVar: CLAUDE_CODE_OVERRIDE_ENV,
+  get bin() {
+    return resolveBin(CLAUDE_CODE_OVERRIDE_ENV, 'claude');
+  },
+  stdinMode: 'pipe',
+  async prepare(systemPrompt, userPrompt, options) {
+    return {
+      args: [
+        '-p',
+        '--output-format', 'text',
+        '--permission-mode', 'default',
+        // Enforceably disable ALL tools. The document text being rewritten is
+        // untrusted and may contain prompt injection; '--tools ""' (per the
+        // Claude Code CLI: empty = disable all tools) ensures the subprocess
+        // can never read/write files or run commands regardless of what the
+        // text tries to coax, rather than relying on a prompt instruction.
+        '--tools', '',
+        // Don't persist a session transcript to disk — a one-shot rewrite must
+        // not leave the user's private document in ~/.claude session history.
+        '--no-session-persistence',
+        // Only the STATIC preamble goes on argv. The humanization system prompt
+        // can embed user-derived content (--style-guide text, flagged sentences
+        // in rehumanize passes), so it travels via stdin with the document to
+        // stay off process listings and clear of ARG_MAX.
+        '--system-prompt', CLAUDE_CODE_NONINTERACTIVE_PREAMBLE,
+        ...(options.model ? ['--model', options.model] : []),
+      ],
+      stdinContent: combinePrompts(systemPrompt, userPrompt),
+    };
+  },
+};
+
+// ==================== Codex ====================
+
+const CODEX_OVERRIDE_ENV = 'STEALTHHUMANIZER_CODEX_BIN';
+
+const CODEX_CONFIG: CliRunnerConfig = {
+  label: 'Codex CLI',
+  overrideEnvVar: CODEX_OVERRIDE_ENV,
+  get bin() {
+    return resolveBin(CODEX_OVERRIDE_ENV, 'codex');
+  },
+  // Prompt is delivered via stdin (see stdinContent below), NOT as an argv
+  // positional: the prompt contains the user's private document, which on argv
+  // would be visible in process listings (ps) and can blow past ARG_MAX on long
+  // inputs. Codex's `<stdin>` block bug only triggers when a positional prompt
+  // AND piped stdin are BOTH supplied; with no positional, stdin is the
+  // documented, sole prompt source.
+  stdinMode: 'pipe',
+  async prepare(systemPrompt, userPrompt, options) {
+    const combined = combinePrompts(systemPrompt, userPrompt);
+    // -o writes only the agent's final message to this file, sparing us from
+    // having to parse Codex's banner + user-echo + assistant-text from stdout.
+    const dir = await mkdtemp(path.join(tmpdir(), 'stealthhumanizer-codex-'));
+    const outputFile = path.join(dir, 'reply.txt');
+
+    return {
+      args: [
+        'exec',
+        '--skip-git-repo-check',
+        '--color', 'never',
+        // Defense-in-depth for untrusted document text. Unlike Claude Code,
+        // Codex exec has no "disable all tools" switch — it can run shell
+        // commands by design — so confine it as tightly as the platform allows:
+        //   --sandbox read-only        : block writes and network
+        //   -C <empty temp dir>        : working root is an empty dir, so any
+        //                                relative file read hits nothing useful
+        //   shell_environment_policy.inherit=none : commands inherit no parent
+        //                                env, so API keys/secrets can't leak
+        // Residual risk (absolute-path reads) is documented in the README; for
+        // fully untrusted input prefer --model claude-code (true no-tools).
+        '--sandbox', 'read-only',
+        '-C', dir,
+        '-c', 'shell_environment_policy.inherit=none',
+        // Don't persist session files to disk — keeps the user's private
+        // document out of Codex's local session history for a one-shot rewrite.
+        '--ephemeral',
+        '-o', outputFile,
+        ...(options.model ? ['--model', options.model] : []),
+      ],
+      // Sole prompt source — keeps the user's document off argv/process listings.
+      stdinContent: combined,
+      finalize: async () => {
+        const reply = await readFile(outputFile, 'utf8');
+        return reply.trim();
+      },
+      cleanup: async () => {
+        await rm(dir, { recursive: true, force: true });
+      },
+    };
+  },
+};
+
+// ==================== Public API ====================
+
+export function claudeCodeGenerate(
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions = {},
+): Promise<string> {
+  return runCli(CLAUDE_CODE_CONFIG, systemPrompt, userPrompt, options);
+}
+
+export function codexGenerate(
+  systemPrompt: string,
+  userPrompt: string,
+  options: CliRunnerOptions = {},
+): Promise<string> {
+  return runCli(CODEX_CONFIG, systemPrompt, userPrompt, options);
+}

--- a/lib/server/providers-runtime.ts
+++ b/lib/server/providers-runtime.ts
@@ -1,0 +1,65 @@
+// Server-only provider dispatcher.
+//
+// Wraps lib/providers.ts's generateWithProvider with CLI-runner support.
+// HTTP providers delegate to lib/providers.ts (same code path the browser
+// uses for direct fetches in Settings/Humanizer). CLI runners (claude-code,
+// codex) are handled here because spawning subprocesses requires Node and
+// can't live in the browser-safe lib/providers.ts.
+//
+// Why a thin wrapper instead of fully owning execution: keeping the HTTP
+// adapters in lib/providers.ts preserves the browser → provider direct call
+// path that the "API keys never touch our server" privacy model relies on.
+
+import { spawn } from 'node:child_process';
+import {
+  ModelProvider,
+  isCliOnlyProvider,
+  generateWithProvider as generateHttpProvider,
+} from '../providers';
+import { claudeCodeGenerate, codexGenerate } from './cli-providers';
+
+interface GenerationOptions {
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  model?: string;
+}
+
+export async function generateWithProvider(
+  provider: ModelProvider,
+  apiKey: string,
+  systemPrompt: string,
+  userPrompt: string,
+  options: GenerationOptions = {},
+): Promise<string> {
+  if (provider === 'claude-code') {
+    const fullUserPrompt = `Text to humanize:\n\n${userPrompt}`;
+    return claudeCodeGenerate(systemPrompt, fullUserPrompt, { model: options.model });
+  }
+  if (provider === 'codex') {
+    const fullUserPrompt = `Text to humanize:\n\n${userPrompt}`;
+    return codexGenerate(systemPrompt, fullUserPrompt, { model: options.model });
+  }
+  return generateHttpProvider(provider, apiKey, systemPrompt, userPrompt, options);
+}
+
+// Re-exported for convenience so server-only callers can import one module.
+// generateAlternatives uses the HTTP-only generateWithProvider internally;
+// it doesn't currently support CLI runners (alternatives are an HTTP-only
+// feature surfaced in the web UI, not the CLI).
+export { generateAlternatives, testApiKey } from '../providers';
+
+/** Best-effort check that a CLI-runner binary is reachable. Spawns
+ *  `<bin> --version` and looks for a zero exit. Returns false for non-CLI
+ *  providers or when the binary isn't found. */
+export async function testCliProvider(provider: ModelProvider): Promise<boolean> {
+  if (!isCliOnlyProvider(provider)) return false;
+  const bin = provider === 'claude-code'
+    ? (process.env.STEALTHHUMANIZER_CLAUDE_CODE_BIN || 'claude')
+    : (process.env.STEALTHHUMANIZER_CODEX_BIN || 'codex');
+  return new Promise<boolean>((resolve) => {
+    const child = spawn(bin, ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('exit', (code) => resolve(code === 0));
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,11 +2,12 @@
 
 // ==================== PROVIDER TYPES ====================
 
-export type ModelProvider = 
-  | 'gemini' | 'openai' | 'claude' 
-  | 'groq' | 'mistral' | 'cohere' 
+export type ModelProvider =
+  | 'gemini' | 'openai' | 'claude'
+  | 'groq' | 'mistral' | 'cohere'
   | 'together' | 'openrouter' | 'cerebras'
-  | 'deepinfra' | 'huggingface' | 'cloudflare' | 'zai';
+  | 'deepinfra' | 'huggingface' | 'cloudflare' | 'zai'
+  | 'claude-code' | 'codex';
 
 export interface Provider {
   id: ModelProvider;
@@ -19,6 +20,10 @@ export interface Provider {
   defaultModel: string;
   models: string[];
   placeholder: string;
+  /** Runs as a local subprocess (e.g. Claude Code, Codex CLI). No API key needed;
+   *  the binary handles auth via its own login state. Not available in browser
+   *  or serverless runtimes. */
+  cliOnly?: boolean;
 }
 
 // ==================== HUMANIZATION TYPES ====================

--- a/scripts/tests/cli.test.mjs
+++ b/scripts/tests/cli.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const cliPath = path.join(repoRoot, "dist/bin/cli.js");
 const mockFetchPath = path.join(repoRoot, "scripts/tests/fixtures/mock-cli-fetch.mjs");
+const fakeCliRunnerPath = path.join(repoRoot, "scripts/tests/fixtures/fake-cli-runner.mjs");
 const providerEnvVars = [
   "GEMINI_API_KEY",
   "OPENAI_API_KEY",
@@ -125,6 +126,8 @@ describe("StealthHumanizer CLI", () => {
     assert.match(result.stdout, /Provider\s+Free\s+Env var\s+Default model\s+Name/);
     assert.match(result.stdout, /gemini\s+yes\s+GEMINI_API_KEY\s+gemini-1\.5-flash/);
     assert.match(result.stdout, /openai\s+no\s+OPENAI_API_KEY\s+gpt-4o/);
+    assert.match(result.stdout, /claude-code\s+yes\s+\(cli\)/);
+    assert.match(result.stdout, /codex\s+yes\s+\(cli\)/);
     assert.equal(result.stderr, "");
   });
 
@@ -132,6 +135,8 @@ describe("StealthHumanizer CLI", () => {
     const providers = parseJsonOutput(await runCli(["providers", "--json"]));
     const gemini = providers.find((provider) => provider.id === "gemini");
     const openai = providers.find((provider) => provider.id === "openai");
+    const claudeCode = providers.find((provider) => provider.id === "claude-code");
+    const codex = providers.find((provider) => provider.id === "codex");
 
     assert.ok(Array.isArray(providers));
     assert.ok(providers.length >= 10);
@@ -140,6 +145,10 @@ describe("StealthHumanizer CLI", () => {
     assert.equal(gemini.defaultModel, "gemini-1.5-flash");
     assert.equal(openai.free, false);
     assert.equal(Object.hasOwn(gemini, "getApiKeyUrl"), true);
+    assert.equal(claudeCode.cliOnly, true);
+    assert.equal(claudeCode.env, null);
+    assert.equal(codex.cliOnly, true);
+    assert.equal(codex.env, null);
   });
 
   test("scores text from --text with readable detector output", async () => {
@@ -315,5 +324,219 @@ describe("StealthHumanizer CLI", () => {
     assert.equal(payload.options.tone, "custom");
     assert.equal(payload.options.customTone, "Use plain, direct language with short paragraphs.");
     assert.equal(payload.options.aggressiveSynonyms, false);
+  });
+
+  test("humanizes via the claude-code CLI runner without an API key", async () => {
+    const recordPath = path.join(tmpRoot, "claude-code-invocations.jsonl");
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: fakeCliRunnerPath,
+      FAKE_CLI_MODE: "success",
+      FAKE_CLI_RECORD_FILE: recordPath,
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertSuccess(result);
+    assert.match(result.stdout, /rewritten paragraph/i);
+    assert.match(result.stdout, /meaning intact/i);
+
+    // The fake binary records what it received. We expect at least one
+    // invocation, prompt delivered via stdin (not argv), and the Claude
+    // Code flag set we hand-rolled in the adapter.
+    const lines = (await fs.readFile(recordPath, "utf8")).trim().split("\n");
+    assert.ok(lines.length >= 1, "expected at least one fake-cli invocation");
+    const first = JSON.parse(lines[0]);
+
+    assert.equal(first.argv[0], "-p", "must use --print mode");
+    const outputFmtIdx = first.argv.indexOf("--output-format");
+    assert.ok(outputFmtIdx >= 0 && first.argv[outputFmtIdx + 1] === "text", "must request text output");
+
+    // Default uses the 'opus' alias so the registry doesn't need a bump when
+    // Anthropic ships new Opus versions.
+    const modelIdx = first.argv.indexOf("--model");
+    assert.ok(modelIdx >= 0, "must pass --model");
+    assert.equal(first.argv[modelIdx + 1], "opus");
+
+    // Regression guards for the Opus-4.7 agentic-preamble bug (2026-05-16):
+    // permission-mode must be forced to 'default' to disable the user's plan
+    // mode, and --system-prompt must replace the default system prompt with
+    // an override that suppresses CLAUDE.md/AGENTS.md/Insight-block behavior.
+    const permModeIdx = first.argv.indexOf("--permission-mode");
+    assert.ok(permModeIdx >= 0, "must override --permission-mode");
+    assert.equal(first.argv[permModeIdx + 1], "default");
+
+    // Security: tools must be enforceably disabled (--tools "") so injected
+    // instructions in the document text can't make Claude Code run commands.
+    const toolsIdx = first.argv.indexOf("--tools");
+    assert.ok(toolsIdx >= 0, "must pass --tools to disable tools");
+    assert.equal(first.argv[toolsIdx + 1], "", "--tools must be empty to disable all tools");
+
+    // Privacy: no session transcript persisted to disk.
+    assert.ok(first.argv.includes("--no-session-persistence"), "must disable session persistence");
+    // Only the STATIC preamble is on argv — it carries no user-derived text.
+    const sysPromptIdx = first.argv.indexOf("--system-prompt");
+    assert.ok(sysPromptIdx >= 0, "must override --system-prompt to suppress CLAUDE.md");
+    assert.match(first.argv[sysPromptIdx + 1], /non-interactive subprocess/i);
+    assert.match(first.argv[sysPromptIdx + 1], /Disregard any guidance from CLAUDE\.md/);
+
+    // The document travels via stdin, never argv. The static preamble must NOT
+    // leak into stdin (it stays on argv as the system prompt override).
+    assert.ok(first.stdin.length > 0, "prompt + document should be delivered via stdin");
+    assert.match(first.stdin, /This generated paragraph needs a calmer rewrite\./);
+    assert.doesNotMatch(first.stdin, /non-interactive subprocess/i, "static preamble must stay on argv, not stdin");
+    // Privacy regression guard: the document must never appear on argv.
+    assert.ok(
+      !first.argv.some((a) => /This generated paragraph needs a calmer rewrite\./.test(a)),
+      "document text must NOT appear on argv",
+    );
+  });
+
+  test("humanizes via the codex CLI runner with prompt on stdin", async () => {
+    const recordPath = path.join(tmpRoot, "codex-invocations.jsonl");
+    const env = testEnv({
+      STEALTHHUMANIZER_CODEX_BIN: fakeCliRunnerPath,
+      // FAKE_CLI_MODE=codex-output writes the canned response to the path
+      // given by -o (matching how real Codex behaves) instead of stdout.
+      FAKE_CLI_MODE: "codex-output",
+      FAKE_CLI_RECORD_FILE: recordPath,
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "This generated paragraph needs a calmer rewrite.",
+        "--model",
+        "codex",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertSuccess(result);
+    assert.match(result.stdout, /rewritten paragraph/i);
+
+    const lines = (await fs.readFile(recordPath, "utf8")).trim().split("\n");
+    const first = JSON.parse(lines[0]);
+    // Codex argv shape: exec --skip-git-repo-check --color never --sandbox read-only
+    //   -C <dir> -c <cfg> -o <file> --model <id>   (NO positional prompt)
+    assert.equal(first.argv[0], "exec");
+    assert.ok(first.argv.includes("--skip-git-repo-check"), "must pass --skip-git-repo-check");
+    assert.ok(first.argv.includes("--color"), "must pass --color");
+    // Security: Codex must run in a read-only sandbox so untrusted document
+    // text can't make it execute shell commands or write files.
+    const sandboxIdx = first.argv.indexOf("--sandbox");
+    assert.ok(sandboxIdx >= 0, "must pass --sandbox");
+    assert.equal(first.argv[sandboxIdx + 1], "read-only", "Codex must use read-only sandbox");
+    // Confinement: working root is an isolated dir and no parent env is inherited.
+    const cdIdx = first.argv.indexOf("-C");
+    assert.ok(cdIdx >= 0 && first.argv[cdIdx + 1], "Codex must set an isolated working root with -C");
+    const cfgIdx = first.argv.indexOf("-c");
+    assert.ok(cfgIdx >= 0, "Codex must pass a -c config override");
+    assert.equal(first.argv[cfgIdx + 1], "shell_environment_policy.inherit=none", "Codex must not inherit parent env");
+    // Privacy: no session files persisted to disk.
+    assert.ok(first.argv.includes("--ephemeral"), "Codex must run ephemerally (no session persistence)");
+    const outputFlagIdx = first.argv.indexOf("-o");
+    assert.ok(outputFlagIdx >= 0, "must pass -o to capture clean output");
+    assert.ok(first.argv[outputFlagIdx + 1], "must follow -o with a path");
+    const modelFlagIdx = first.argv.indexOf("--model");
+    assert.ok(modelFlagIdx >= 0, "must pass --model");
+    assert.equal(first.argv[modelFlagIdx + 1], "gpt-5.5");
+    // Privacy: the prompt (system + user document) must travel via stdin, NOT
+    // argv — argv is visible in process listings and capped by ARG_MAX.
+    assert.ok(
+      !first.argv.some((a) => /This generated paragraph needs a calmer rewrite\./.test(a)),
+      "user document must NOT appear on argv",
+    );
+    assert.equal(first.stdinKind, "pipe", "Codex prompt must be delivered via piped stdin");
+    assert.match(first.stdin, /This generated paragraph needs a calmer rewrite\./);
+  });
+
+  test("surfaces the CLI runner's stderr when it exits non-zero", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: fakeCliRunnerPath,
+      FAKE_CLI_MODE: "fail",
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Anything.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /Claude Code exited 1/);
+    assert.match(result.stderr, /fake cli boom/);
+  });
+
+  test("reports a missing binary clearly when ENOENT occurs", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: "/nonexistent/path/to/claude",
+    });
+
+    const result = await runCli(
+      [
+        "humanize",
+        "--text",
+        "Anything.",
+        "--model",
+        "claude-code",
+        "--quiet",
+      ],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /not found on PATH/);
+    assert.match(result.stderr, /STEALTHHUMANIZER_CLAUDE_CODE_BIN/);
+  });
+
+  test("missing Codex binary names the Codex override, not the Claude one", async () => {
+    const env = testEnv({
+      STEALTHHUMANIZER_CODEX_BIN: "/nonexistent/path/to/codex",
+    });
+
+    const result = await runCli(
+      ["humanize", "--text", "Anything.", "--model", "codex", "--quiet"],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.match(result.stderr, /not found on PATH/);
+    assert.match(result.stderr, /STEALTHHUMANIZER_CODEX_BIN/);
+    assert.doesNotMatch(result.stderr, /STEALTHHUMANIZER_CLAUDE_CODE_BIN/);
+  });
+
+  test("CLI-runner provider does not require --api-key flag", async () => {
+    // Regression: ensure the cliOnly branch in resolveApiKey actually short-
+    // circuits the "Missing API key" error. We point at a nonexistent binary
+    // so the spawn fails fast, but the error must NOT be about the API key.
+    const env = testEnv({
+      STEALTHHUMANIZER_CLAUDE_CODE_BIN: "/nonexistent/path/to/claude",
+    });
+
+    const result = await runCli(
+      ["humanize", "--text", "Anything.", "--model", "claude-code", "--quiet"],
+      { env },
+    );
+
+    assertFailure(result);
+    assert.doesNotMatch(result.stderr, /Missing API key/);
   });
 });

--- a/scripts/tests/fixtures/fake-cli-runner.mjs
+++ b/scripts/tests/fixtures/fake-cli-runner.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Fake Claude Code / Codex binary used by cli.test.mjs to exercise the
+// subprocess provider path without requiring the real CLIs to be installed.
+//
+// Behavior is controlled by env vars set by the test:
+//   FAKE_CLI_MODE=success       — emit a canned humanized paragraph on stdout
+//   FAKE_CLI_MODE=codex-output  — write the canned reply to the path given by
+//                                  -o <file> (mimics real Codex), plus some
+//                                  banner-ish noise on stdout
+//   FAKE_CLI_MODE=formatted      — emit a markdown-ish technical response with
+//                                  blank lines and protected tokens
+//   FAKE_CLI_MODE=fail          — write to stderr and exit 1
+//   FAKE_CLI_MODE=echo-args     — emit the argv as JSON (for arg assertions)
+//   FAKE_CLI_RECORD_FILE=<path> — append a JSON line per invocation with
+//                                  { argv, stdin, stdinKind } for the test
+//                                  to inspect
+
+import { readFileSync, appendFileSync, writeFileSync, fstatSync } from "node:fs";
+
+const mode = process.env.FAKE_CLI_MODE ?? "success";
+const record = process.env.FAKE_CLI_RECORD_FILE;
+
+function readStdinSync() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function classifyStdin() {
+  try {
+    const stat = fstatSync(0);
+    // Node's child_process.spawn uses Unix domain socket pairs (not POSIX
+    // FIFOs) on macOS for stdio: 'pipe'. On Linux it uses pipes. Treat both
+    // as "pipe" — the semantic we care about is "data can flow in".
+    if (stat.isFIFO() || stat.isSocket()) return "pipe";
+    if (stat.isCharacterDevice()) {
+      return process.stdin.isTTY ? "tty" : "char";
+    }
+    if (stat.isFile()) return "file";
+    return "other";
+  } catch {
+    return "closed";
+  }
+}
+
+const stdinKind = classifyStdin();
+// Only attempt to read stdin if it's a pipe — reading from /dev/null is
+// harmless but makes the test's intent ambiguous.
+const stdin = stdinKind === "pipe" ? readStdinSync() : "";
+const argv = process.argv.slice(2);
+
+if (record) {
+  appendFileSync(
+    record,
+    JSON.stringify({ argv, stdin, stdinKind }) + "\n",
+    "utf8",
+  );
+}
+
+const CANNED_REPLY =
+  "This rewritten paragraph keeps its meaning intact. It reads naturally now.";
+const FORMATTED_TECHNICAL_REPLY = `Verifier 0: binary integrity.
+
+Before running anything, hash \`validator\` and \`bin/linux-x86_64/license_validator\`.
+
+Reference hash: \`75d494fe14ad865b15a392c4d2317755a0ab771916ef53b78331d593cfc66193\`.
+Version: Zig 0.15.2.`;
+
+if (mode === "fail") {
+  process.stderr.write("fake cli boom\n");
+  process.exit(1);
+}
+
+if (mode === "echo-args") {
+  process.stdout.write(JSON.stringify({ argv, stdin, stdinKind }));
+  process.exit(0);
+}
+
+if (mode === "codex-output") {
+  // Mimic Codex's `-o <file>` behavior: write the reply to the file argument
+  // and put banner-ish noise on stdout (which the adapter should ignore).
+  const outputFlagIdx = argv.indexOf("-o");
+  if (outputFlagIdx === -1 || !argv[outputFlagIdx + 1]) {
+    process.stderr.write("fake codex requires -o <file>\n");
+    process.exit(1);
+  }
+  writeFileSync(argv[outputFlagIdx + 1], CANNED_REPLY + "\n", "utf8");
+  process.stdout.write("[fake codex banner: would print logs here]\n");
+  process.exit(0);
+}
+
+if (mode === "formatted") {
+  process.stdout.write(FORMATTED_TECHNICAL_REPLY + "\n");
+  process.exit(0);
+}
+
+// default ("success"): emit a canned, on-brand humanized paragraph
+process.stdout.write(CANNED_REPLY + "\n");


### PR DESCRIPTION
Rebased version of #112 (from @jhubbardsf) — resolved merge conflicts after #109 was squash-merged.

Supersedes #112. All credit to @jhubbardsf for the implementation.

## Summary

Adds two `cliOnly` providers that humanize by spawning a local CLI you're already logged into — no API key:

- **`--model claude-code`** spawns your local `claude` CLI (Claude Code)
- **`--model codex`** spawns your local `codex` CLI (OpenAI Codex)

## Architecture

- **`lib/server/cli-providers.ts`** — subprocess adapters with security hardening
- **`lib/server/providers-runtime.ts`** — server-only wrapper keeping browser bundle clean
- All 5 API routes reject `cliOnly` providers (including chains) with 400
- CLI runners confined: `claude-code` with `--tools ""`, `codex` with `--sandbox read-only`
- Prompts via stdin (not argv) for privacy

## Security (Codex GPT-5.5 reviewed — all clean)

- Web API rejects CLI providers + chain entries
- Tools disabled / sandboxed, no session persistence
- Untrusted input contained, residual risks documented in README

## Verification

- `npm run test:cli` → 17/17 pass (12 existing + 5 new)
- `npm run build` → clean, no `node:child_process` in browser bundle
- `eslint` → 0 errors