### PR TITLE
Add local GPTZero/grammar fallbacks, robust rehumanize logic, and UI updates

### DIFF
--- a/app/api/detect/route.ts
+++ b/app/api/detect/route.ts
@@ -17,7 +17,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, data: result });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Internal error';
-    const status = message.includes('API key') ? 503 : 500;
-    return NextResponse.json({ success: false, error: message }, { status });
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/grammar/route.ts
+++ b/app/api/grammar/route.ts
@@ -2,34 +2,54 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getProvider, isCliOnlyProvider } from '@/lib/providers';
 import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { GRAMMAR_CHECK_SYSTEM_PROMPT } from '@/lib/prompts';
+import { checkGrammarLocally, normalizeGrammarPayload, parseFirstJsonObject } from '@/lib/grammar';
+import { ModelProvider } from '@/lib/types';
 
 export async function POST(request: NextRequest) {
   try {
     const { text, model, apiKey } = await request.json();
-    if (!text || !model || !apiKey) return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
-    if (isCliOnlyProvider(model)) return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
+    if (!text || typeof text !== 'string' || text.trim().length === 0) {
+      return NextResponse.json({ success: false, error: 'text is required' }, { status: 400 });
+    }
+    if (text.length > 50000) {
+      return NextResponse.json({ success: false, error: 'Text exceeds 50,000 character limit' }, { status: 400 });
+    }
 
-    const providerInfo = getProvider(model);
-    const modelId = providerInfo?.defaultModel || model;
+    if (!model || !apiKey) {
+      const local = checkGrammarLocally(text);
+      return NextResponse.json({ success: true, ...local, warning: 'No model/API key supplied; used the local grammar fallback.' });
+    }
 
-    const result = await generateWithProvider(
-      model, apiKey,
-      GRAMMAR_CHECK_SYSTEM_PROMPT,
-      text,
-      { temperature: 0.2, maxTokens: 2048, model: modelId }
-    );
+    if (isCliOnlyProvider(model as ModelProvider)) {
+      return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
+    }
 
-    const jsonMatch = result.match(/\{[\s\S]*\}/);
-    if (jsonMatch) {
-      const parsed = JSON.parse(jsonMatch[0]);
-      return NextResponse.json({ success: true,
-        issues: parsed.issues || [],
-        correctedText: parsed.correctedText || text,
+    try {
+      const providerInfo = getProvider(model as ModelProvider);
+      const modelId = providerInfo?.defaultModel || model;
+      const result = await generateWithProvider(
+        model as ModelProvider,
+        apiKey,
+        GRAMMAR_CHECK_SYSTEM_PROMPT,
+        text,
+        { temperature: 0.1, maxTokens: 2048, model: modelId }
+      );
+
+      const parsed = normalizeGrammarPayload(parseFirstJsonObject(result), text, 'llm');
+      if (parsed) return NextResponse.json({ success: true, ...parsed });
+    } catch (err: unknown) {
+      const local = checkGrammarLocally(text);
+      return NextResponse.json({
+        success: true,
+        ...local,
+        warning: err instanceof Error ? `LLM grammar check failed; used local fallback. ${err.message}` : 'LLM grammar check failed; used local fallback.',
       });
     }
 
-    return NextResponse.json({ success: false, error: 'Failed to parse grammar check results' }, { status: 500 });
-  } catch (err: any) {
-    return NextResponse.json({ success: false, error: err.message || 'Internal error' }, { status: 500 });
+    const local = checkGrammarLocally(text);
+    return NextResponse.json({ success: true, ...local, warning: 'Could not parse LLM grammar JSON; used local fallback.' });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Internal error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/rehumanize/route.ts
+++ b/app/api/rehumanize/route.ts
@@ -3,44 +3,104 @@ import { getRehumanizePrompt } from '@/lib/prompts';
 import { getProvider, isCliOnlyProvider } from '@/lib/providers';
 import { generateWithProvider } from '@/lib/server/providers-runtime';
 import { postprocess } from '@/lib/postprocess';
+import { detectAI } from '@/lib/detector';
+import { ModelProvider, StylePreset } from '@/lib/types';
+import { chooseImprovedRewrite, parseRehumanizedLines, replaceSentencesInText } from '@/lib/rehumanize';
 
 export async function POST(request: NextRequest) {
   try {
     const { flaggedSentences, level, style, tone, customTone, model, apiKey, fullText, purpose } = await request.json();
-    if (!flaggedSentences?.length || !model || !apiKey) {
-      return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    if (!Array.isArray(flaggedSentences) || flaggedSentences.length === 0) {
+      return NextResponse.json({ success: false, error: 'flaggedSentences is required' }, { status: 400 });
     }
-    if (isCliOnlyProvider(model)) {
+    if (!model || !apiKey) {
+      return NextResponse.json({ success: false, error: 'model and apiKey are required for re-humanization' }, { status: 400 });
+    }
+    if (isCliOnlyProvider(model as ModelProvider)) {
       return NextResponse.json({ success: false, error: `Provider "${model}" is a local CLI runner and is not available over the web API. Use the stealthhumanizer CLI.` }, { status: 400 });
     }
 
-    const providerInfo = getProvider(model);
-    const modelId = providerInfo?.defaultModel || model;
+    const cleanFlagged = flaggedSentences
+      .filter((sentence): sentence is string => typeof sentence === 'string')
+      .map(sentence => sentence.trim())
+      .filter(sentence => sentence.length > 0)
+      .slice(0, 30);
 
-    const rehumanizePrompt = getRehumanizePrompt(flaggedSentences, level || 'aggressive', style || 'humanize', tone || 'conversational', customTone, purpose);
-    
-    const result = await generateWithProvider(model, apiKey, rehumanizePrompt, '', { model: modelId, temperature: 0.7, topP: 0.9 });
-    const rehumanized = result
-      .split('\n')
-      .map(l => l.replace(/^\d+[\.\)]\s*/, '').trim())
-      .filter(l => l.length > 10);
-
-    // Replace flagged sentences in full text
-    if (fullText) {
-      let newText = fullText;
-      let replacementIdx = 0;
-      for (const flagged of flaggedSentences) {
-        if (replacementIdx < rehumanized.length) {
-          newText = newText.replace(flagged, rehumanized[replacementIdx]);
-          replacementIdx++;
-        }
-      }
-      const processedText = postprocess(newText, { style: (style || 'humanize') as any, light: true });
-      return NextResponse.json({ success: true, rehumanizedSentences: rehumanized, fullText: processedText });
+    if (cleanFlagged.length === 0) {
+      return NextResponse.json({ success: false, error: 'No valid flagged sentences supplied' }, { status: 400 });
     }
 
-    return NextResponse.json({ success: true, rehumanizedSentences: rehumanized, fullText: postprocess(rehumanized.join(' '), { style: (style || 'humanize') as any }) });
-  } catch (err: any) {
-    return NextResponse.json({ success: false, error: err.message || 'Internal error' }, { status: 500 });
+    const providerInfo = getProvider(model as ModelProvider);
+    const modelId = providerInfo?.defaultModel || model;
+    const beforeDetection = detectAI(fullText || cleanFlagged.join(' '));
+    let rawRewrites: string[] = [];
+    let usedFallback = false;
+
+    try {
+      const rehumanizePrompt = getRehumanizePrompt(cleanFlagged, level || 'ninja', style || 'humanize', tone || 'conversational', customTone, purpose);
+      const contextPrompt = fullText
+        ? `${rehumanizePrompt}\n\nFULL TEXT CONTEXT (do not rewrite all of this; only rewrite the numbered flagged sentences above):\n"""\n${String(fullText).slice(0, 6000)}\n"""`
+        : rehumanizePrompt;
+      const result = await generateWithProvider(model as ModelProvider, apiKey, contextPrompt, '', {
+        model: modelId,
+        temperature: 0.95,
+        topP: 0.95,
+        maxTokens: Math.min(4096, Math.max(1024, cleanFlagged.join(' ').length * 2)),
+      });
+      rawRewrites = parseRehumanizedLines(result);
+    } catch {
+      usedFallback = true;
+    }
+
+    const replacements = cleanFlagged.map((original, index) => ({
+      original,
+      replacement: chooseImprovedRewrite(original, rawRewrites[index], index),
+    }));
+    usedFallback = usedFallback || replacements.some((item, index) => item.replacement !== rawRewrites[index]);
+
+    // Only replace the flagged spans. Do not post-process the whole document here,
+    // because that can rewrite unflagged text and make the score regress.
+    const joined = replacements.map(item => item.replacement).join(' ');
+    let finalText = fullText ? replaceSentencesInText(fullText, replacements) : postprocess(joined, { style: (style || 'humanize') as StylePreset, light: true });
+    let afterDetection = detectAI(finalText);
+    let acceptedReplacements = replacements;
+    let skippedDueToRegression = false;
+
+    if (fullText && afterDetection.score < beforeDetection.score) {
+      const nonRegressing = replacements.filter(({ original, replacement }) => {
+        const originalSentenceScore = detectAI(original).sentences[0]?.score ?? detectAI(original).score;
+        const replacementSentenceScore = detectAI(replacement).sentences[0]?.score ?? detectAI(replacement).score;
+        return replacementSentenceScore >= originalSentenceScore;
+      });
+      const candidateText = nonRegressing.length > 0 ? replaceSentencesInText(fullText, nonRegressing) : fullText;
+      const candidateDetection = detectAI(candidateText);
+
+      if (candidateDetection.score >= beforeDetection.score) {
+        finalText = candidateText;
+        afterDetection = candidateDetection;
+        acceptedReplacements = nonRegressing;
+      } else {
+        finalText = fullText;
+        afterDetection = beforeDetection;
+        acceptedReplacements = [];
+        skippedDueToRegression = true;
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      rehumanizedSentences: acceptedReplacements.map(item => item.replacement),
+      replacements: acceptedReplacements,
+      fullText: finalText,
+      scoreBefore: beforeDetection.score,
+      scoreAfter: afterDetection.score,
+      improved: afterDetection.score > beforeDetection.score,
+      fallbackUsed: usedFallback,
+      changedOnlyFlaggedSpans: Boolean(fullText),
+      skippedDueToRegression,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Internal error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
 }

--- a/components/Humanizer.tsx
+++ b/components/Humanizer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Sparkles, Copy, Download, FileText, RefreshCw, Zap, Eye,
   FileDown, Target, ChevronDown, ChevronUp, Keyboard, ArrowRight,
@@ -8,8 +8,8 @@ import {
   X, FileUp, BarChart2, Shield
 } from 'lucide-react';
 import { RewriteLevel, StylePreset, TonePreset, TextPurpose, HumanizationResult, ModelProvider } from '@/lib/types';
-import { TONE_CONFIGS, SAMPLE_AI_TEXT, SAMPLE_TECHNICAL_TEXT, PURPOSE_CONFIGS } from '@/lib/prompts';
-import { detectAI, getScoreColor, getScoreBarColor } from '@/lib/detector';
+import { SAMPLE_AI_TEXT, SAMPLE_TECHNICAL_TEXT } from '@/lib/prompts';
+import { detectAI, getScoreColor } from '@/lib/detector';
 import { getReadabilityLabel } from '@/lib/readability';
 import { countWords, downloadAsTxt, downloadAsDocx, downloadAsMarkdown, getApiKeys } from '@/lib/storage';
 import { WEB_PROVIDERS as PROVIDERS } from '@/lib/providers';
@@ -145,6 +145,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
   const [gptzeroHumanized, setGptzeroHumanized] = useState<number | null>(null);
   const [gptzeroLoading, setGptzeroLoading] = useState(false);
   const [gptzeroUnavailable, setGptzeroUnavailable] = useState(false);
+  const [gptzeroSource, setGptzeroSource] = useState<'gptzero' | 'local-fallback' | null>(null);
 
   // Comparison chart visibility (Phase 4)
   const [showComparisonChart, setShowComparisonChart] = useState(false);
@@ -193,7 +194,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
     return { providerId, apiKey };
   };
 
-  const handleHumanize = useCallback(async () => {
+  async function handleHumanize() {
     if (!inputText.trim()) { showToast('warning', 'Please enter some text to humanize.'); return; }
     if (wordCount > 10000) { showToast('warning', 'Maximum 10,000 words per input.'); return; }
     const { providerId, apiKey } = getApiCredentials();
@@ -252,9 +253,9 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
       setLoading(false);
       setProgress({ pass: 0, max: 0, message: '' });
     }
-  }, [inputText, level, style, tone, customTone, language, targetScore, showToast, wordCount, preferredModel, writingSample, purpose, enablePostprocess, enableChain, selectedChainModels, maxOutputWords]);
+  }
 
-  const handleCopy = () => { if (result) { navigator.clipboard.writeText(result.fullText); showToast('success', 'Copied!'); } };
+  function handleCopy() { if (result) { navigator.clipboard.writeText(result.fullText); showToast('success', 'Copied!'); } }
   const handleDownload = (format: 'txt' | 'docx' | 'md') => {
     if (result) {
       if (format === 'txt') downloadAsTxt(result.fullText, 'humanized');
@@ -320,7 +321,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
   };
 
   // Auto-continue rehumanization until 100% (called after initial humanize)
-  const autoRehumanize = async (initialResult: any) => {
+  async function autoRehumanize(initialResult: HumanizationResult) {
     const { providerId, apiKey } = getApiCredentials();
     if (!apiKey) return;
 
@@ -345,7 +346,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             flaggedSentences: flagged, level: 'ninja', style, tone, customTone,
-            model: providerId, apiKey, fullText: currentFullText,
+            model: providerId, apiKey, fullText: currentFullText, purpose,
           }),
         });
         if (!resp.ok) break;
@@ -354,11 +355,14 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
         const newDetection = detectAI(candidateText);
         const newScore = newDetection.score;
 
-        if (newScore >= currentScore) {
+        const changed = candidateText.trim() !== currentFullText.trim();
+        if (newScore > currentScore || (newScore === currentScore && changed && data.fallbackUsed)) {
           currentFullText = candidateText;
           currentScore = newScore;
         } else {
-          showToast('warning', `Stopped auto-refine: round ${round} would reduce score (${currentScore}% → ${newScore}%).`);
+          showToast('warning', changed
+            ? `Stopped auto-refine: round ${round} did not improve the score (${currentScore}% → ${newScore}%).`
+            : `Stopped auto-refine: round ${round} returned no usable changes.`);
           break;
         }
       }
@@ -399,7 +403,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
       setLoading(false);
       setProgress({ pass: 0, max: 0, message: '' });
     }
-  };
+  }
 
   // Re-humanize flagged sentences (manual trigger)
   const handleRehumanize = async () => {
@@ -427,7 +431,7 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             flaggedSentences: flagged, level: 'ninja', style, tone, customTone,
-            model: providerId, apiKey, fullText: currentFullText,
+            model: providerId, apiKey, fullText: currentFullText, purpose,
           }),
         });
         if (!resp.ok) break;
@@ -436,11 +440,14 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
         const candidateText = data.fullText;
         const newDetection = detectAI(candidateText);
         const newScore = newDetection.score;
-        if (newScore >= currentScore) {
+        const changed = candidateText.trim() !== currentFullText.trim();
+        if (newScore > currentScore || (newScore === currentScore && changed && data.fallbackUsed)) {
           currentFullText = candidateText;
           currentScore = newScore;
         } else {
-          showToast('warning', `Stopped: round ${round} would reduce score (${currentScore}% → ${newScore}%).`);
+          showToast('warning', changed
+            ? `Stopped: round ${round} did not improve the score (${currentScore}% → ${newScore}%).`
+            : `Stopped: round ${round} returned no usable changes.`);
           break;
         }
       }
@@ -491,7 +498,6 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
   const handleGrammarCheck = async () => {
     if (!result) return;
     const { providerId, apiKey } = getApiCredentials();
-    if (!apiKey) { showToast('warning', 'No API key configured'); return; }
 
     setGrammarChecking(true);
     try {
@@ -499,14 +505,15 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: result.fullText, model: providerId, apiKey }),
       });
-      if (!resp.ok) throw new Error('Grammar check failed');
+      if (!resp.ok) { const err = await resp.json().catch(() => ({})); throw new Error(err.error || 'Grammar check failed'); }
       const data = await resp.json();
       setGrammarIssues(data.issues || []);
       setCorrectedText(data.correctedText || result.fullText);
-      if (data.issues.length === 0) {
+      if (data.warning) showToast('warning', data.warning);
+      if ((data.issues || []).length === 0) {
         showToast('success', 'No grammar issues found! ✅');
       } else {
-        showToast('info', `Found ${data.issues.length} issue(s)`);
+        showToast('info', `Found ${(data.issues || []).length} issue(s)`);
       }
     } catch (err: any) {
       showToast('error', err.message);
@@ -544,19 +551,17 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
     if (!result) return;
     setGptzeroLoading(true);
     setGptzeroUnavailable(false);
+    setGptzeroSource(null);
     try {
       const [origRes, humRes] = await Promise.all([
         fetch('/api/detect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: inputText }) }),
         fetch('/api/detect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: result.fullText }) }),
       ]);
 
-      if (origRes.status === 503 || humRes.status === 503) {
-        setGptzeroUnavailable(true);
-        showToast('warning', 'GPTZero API key not configured. Set GPTZERO_API_KEY to enable.');
-        return;
-      }
-
       const [origData, humData] = await Promise.all([origRes.json(), humRes.json()]);
+      if (!origRes.ok || !humRes.ok || !origData.success || !humData.success) {
+        throw new Error(origData.error || humData.error || 'Detection failed');
+      }
       // Handle both old and new response formats
       const origPayload = origData.data ?? origData;
       const humPayload = humData.data ?? humData;
@@ -564,7 +569,12 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
       const humScore = typeof humPayload.score === 'number' ? Math.round(humPayload.score * 100) : null;
       setGptzeroOriginal(origScore);
       setGptzeroHumanized(humScore);
-      showToast('success', 'GPTZero scores loaded!');
+      const source = origPayload.source === 'local-fallback' || humPayload.source === 'local-fallback' ? 'local-fallback' : 'gptzero';
+      setGptzeroSource(source);
+      setGptzeroUnavailable(source === 'local-fallback');
+      showToast(source === 'gptzero' ? 'success' : 'warning', source === 'gptzero'
+        ? 'GPTZero scores loaded!'
+        : 'GPTZero API key unavailable or failed; showing local detector fallback.');
     } catch {
       showToast('error', 'GPTZero detection failed.');
     } finally {
@@ -1268,28 +1278,27 @@ export default function Humanizer({ showToast, onGoToSettings, isFirstVisit }: H
       {result && (gptzeroOriginal !== null || gptzeroHumanized !== null || gptzeroUnavailable) && (
         <div className="bg-dark-800/50 border border-purple-500/30 rounded-xl p-4 animate-fade-in">
           <h3 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
-            <Shield className="w-4 h-4 text-purple-400" /> GPTZero Detection — Before vs After
+            <Shield className="w-4 h-4 text-purple-400" /> {gptzeroSource === 'local-fallback' ? 'Local Detection Fallback' : 'GPTZero Detection'} — Before vs After
           </h3>
-          {gptzeroUnavailable ? (
-            <p className="text-sm text-yellow-400">⚠️ GPTZero API key not configured. Set <code className="bg-dark-700 px-1 rounded text-xs">GPTZERO_API_KEY</code> in your environment to enable real detection scoring.</p>
-          ) : (
-            <div className="grid grid-cols-2 gap-4">
-              <div className="bg-dark-700/30 rounded-lg p-4 text-center">
-                <p className="text-xs text-dark-400 mb-1">Original (AI probability)</p>
-                <p className={`text-3xl font-bold ${gptzeroOriginal !== null && gptzeroOriginal > 50 ? 'text-red-400' : 'text-green-400'}`}>
-                  {gptzeroOriginal !== null ? `${gptzeroOriginal}%` : '—'}
-                </p>
-                <p className="text-xs text-dark-500 mt-1">Before humanization</p>
-              </div>
-              <div className="bg-dark-700/30 rounded-lg p-4 text-center">
-                <p className="text-xs text-dark-400 mb-1">Humanized (AI probability)</p>
-                <p className={`text-3xl font-bold ${gptzeroHumanized !== null && gptzeroHumanized > 50 ? 'text-red-400' : 'text-green-400'}`}>
-                  {gptzeroHumanized !== null ? `${gptzeroHumanized}%` : '—'}
-                </p>
-                <p className="text-xs text-dark-500 mt-1">After humanization</p>
-              </div>
-            </div>
+          {gptzeroUnavailable && (
+            <p className="text-sm text-yellow-400 mb-3">⚠️ Official GPTZero API scoring requires <code className="bg-dark-700 px-1 rounded text-xs">GPTZERO_API_KEY</code>. These numbers are from the local fallback detector, not GPTZero. <a href="https://gptzero.me/" target="_blank" rel="noreferrer" className="underline hover:text-yellow-300">Open GPTZero</a></p>
           )}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-dark-700/30 rounded-lg p-4 text-center">
+              <p className="text-xs text-dark-400 mb-1">Original (AI probability)</p>
+              <p className={`text-3xl font-bold ${gptzeroOriginal !== null && gptzeroOriginal > 50 ? 'text-red-400' : 'text-green-400'}`}>
+                {gptzeroOriginal !== null ? `${gptzeroOriginal}%` : '—'}
+              </p>
+              <p className="text-xs text-dark-500 mt-1">Before humanization</p>
+            </div>
+            <div className="bg-dark-700/30 rounded-lg p-4 text-center">
+              <p className="text-xs text-dark-400 mb-1">Humanized (AI probability)</p>
+              <p className={`text-3xl font-bold ${gptzeroHumanized !== null && gptzeroHumanized > 50 ? 'text-red-400' : 'text-green-400'}`}>
+                {gptzeroHumanized !== null ? `${gptzeroHumanized}%` : '—'}
+              </p>
+              <p className="text-xs text-dark-500 mt-1">After humanization</p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/lib/gptzero.ts
+++ b/lib/gptzero.ts
@@ -1,15 +1,36 @@
+import { detectAI } from './detector';
+
 const GPTZERO_API_URL = 'https://api.gptzero.me/v2/predict/text';
 
 export interface GPTZeroResult {
+  /** AI probability from 0 to 1 when source is GPTZero or local fallback. */
   score: number | null;
   verdict: string | null;
   sentences: unknown[];
+  source: 'gptzero' | 'local-fallback';
+  message?: string;
+}
+
+function localFallback(text: string, message: string): GPTZeroResult {
+  const local = detectAI(text);
+  return {
+    score: Math.max(0, Math.min(1, (100 - local.score) / 100)),
+    verdict: local.overallVerdict === 'ai' ? 'generated' : local.overallVerdict,
+    sentences: local.sentences.map(sentence => ({
+      text: sentence.text,
+      generated_prob: Math.max(0, Math.min(1, (100 - sentence.score) / 100)),
+      classification: sentence.classification,
+      issues: sentence.issues,
+    })),
+    source: 'local-fallback',
+    message,
+  };
 }
 
 export async function detectWithGPTZero(text: string): Promise<GPTZeroResult> {
-  const apiKey = process.env.GPTZERO_API_KEY;
+  const apiKey = process.env.GPTZERO_API_KEY?.trim();
   if (!apiKey) {
-    throw new Error('GPTZero API key is not configured. Set GPTZERO_API_KEY in your environment.');
+    return localFallback(text, 'GPTZero API key is not configured. Using the local detector fallback instead.');
   }
 
   let lastError: Error | null = null;
@@ -47,16 +68,18 @@ export async function detectWithGPTZero(text: string): Promise<GPTZeroResult> {
         score: doc.completely_generated_prob ?? doc.average_generated_prob ?? null,
         verdict: doc.predicted_class ?? null,
         sentences: doc.sentences ?? [],
+        source: 'gptzero',
       };
     } catch (err: unknown) {
       clearTimeout(timeout);
       if (err instanceof Error && err.name === 'AbortError') {
-        throw new Error('GPTZero API request timed out (15s)');
+        lastError = new Error('GPTZero API request timed out (15s)');
+      } else {
+        lastError = err instanceof Error ? err : new Error('Unknown error');
       }
-      lastError = err instanceof Error ? err : new Error('Unknown error');
       if (attempt < maxRetries) continue;
     }
   }
 
-  throw lastError || new Error('GPTZero detection failed');
+  return localFallback(text, lastError?.message ? `GPTZero request failed; using local fallback. ${lastError.message}` : 'GPTZero request failed; using local fallback.');
 }

--- a/lib/grammar.ts
+++ b/lib/grammar.ts
@@ -1,0 +1,145 @@
+export interface GrammarIssue {
+  type: 'grammar' | 'spelling' | 'punctuation' | 'phrasing';
+  original: string;
+  suggestion: string;
+  explanation: string;
+}
+
+export interface GrammarCheckResult {
+  issues: GrammarIssue[];
+  correctedText: string;
+  source: 'llm' | 'local-fallback';
+}
+
+const LOCAL_RULES: Array<{
+  type: GrammarIssue['type'];
+  pattern: RegExp;
+  replacement: string | ((match: string, ...args: string[]) => string);
+  explanation: string;
+}> = [
+  { type: 'spelling', pattern: /\bgrammer\b/gi, replacement: 'grammar', explanation: 'Corrects a common spelling mistake.' },
+  { type: 'spelling', pattern: /\bbeofre\b/gi, replacement: 'before', explanation: 'Corrects a common spelling mistake.' },
+  { type: 'spelling', pattern: /\beveryhting\b/gi, replacement: 'everything', explanation: 'Corrects a common spelling mistake.' },
+  { type: 'grammar', pattern: /\bi\b/g, replacement: 'I', explanation: 'Capitalizes the first-person pronoun.' },
+  { type: 'grammar', pattern: /\b([Tt])here is (\w+) (?:that|who|which) are\b/g, replacement: '$1here are $2 that are', explanation: 'Fixes subject-verb agreement.' },
+  { type: 'grammar', pattern: /\b([Tt])here are (\w+) (?:that|who|which) is\b/g, replacement: '$1here is $2 that is', explanation: 'Fixes subject-verb agreement.' },
+  { type: 'grammar', pattern: /\b([Hh]e|[Ss]he|[Ii]t) are\b/g, replacement: '$1 is', explanation: 'Uses the singular verb form with a singular subject.' },
+  { type: 'grammar', pattern: /\b([Tt]hey|[Ww]e|[Yy]ou) is\b/g, replacement: '$1 are', explanation: 'Uses the plural verb form with a plural subject.' },
+  { type: 'grammar', pattern: /\bdoes not has\b/gi, replacement: 'does not have', explanation: 'Uses the base verb after “does”.' },
+  { type: 'grammar', pattern: /\bdid not (\w+)ed\b/gi, replacement: 'did not $1', explanation: 'Uses the base verb after “did”.' },
+  { type: 'phrasing', pattern: /\bin order to\b/gi, replacement: 'to', explanation: 'Removes wordy phrasing.' },
+  { type: 'phrasing', pattern: /\bdue to the fact that\b/gi, replacement: 'because', explanation: 'Replaces wordy phrasing with a clearer word.' },
+  { type: 'punctuation', pattern: /\s+([,.;:!?])/g, replacement: '$1', explanation: 'Removes spaces before punctuation.' },
+  { type: 'punctuation', pattern: /([,.;:!?])([^\s”’"')\]}])/g, replacement: '$1 $2', explanation: 'Adds a missing space after punctuation.' },
+  { type: 'punctuation', pattern: /\s{2,}/g, replacement: ' ', explanation: 'Collapses repeated spaces.' },
+];
+
+function preserveCase(original: string, replacement: string): string {
+  if (original.toUpperCase() === original) return replacement.toUpperCase();
+  if (original[0]?.toUpperCase() === original[0]) return replacement[0].toUpperCase() + replacement.slice(1);
+  return replacement;
+}
+
+function addIssue(issues: GrammarIssue[], type: GrammarIssue['type'], original: string, suggestion: string, explanation: string) {
+  if (!original || original === suggestion) return;
+  if (issues.some(issue => issue.original === original && issue.suggestion === suggestion)) return;
+  issues.push({ type, original, suggestion, explanation });
+}
+
+function capitalizeSentenceStarts(text: string, issues: GrammarIssue[]): string {
+  return text.replace(/(^|[.!?]\s+)([a-z])/g, (match, prefix: string, letter: string) => {
+    const suggestion = `${prefix}${letter.toUpperCase()}`;
+    addIssue(issues, 'punctuation', match, suggestion, 'Capitalizes the first letter of a sentence.');
+    return suggestion;
+  });
+}
+
+function ensureTerminalPunctuation(text: string, issues: GrammarIssue[]): string {
+  const trimmed = text.trimEnd();
+  if (!trimmed || /[.!?]$/.test(trimmed)) return text;
+  addIssue(issues, 'punctuation', trimmed.slice(-30), `${trimmed.slice(-30)}.`, 'Adds missing terminal punctuation.');
+  return `${trimmed}.`;
+}
+
+export function checkGrammarLocally(text: string): GrammarCheckResult {
+  const issues: GrammarIssue[] = [];
+  let correctedText = text;
+
+  for (const rule of LOCAL_RULES) {
+    correctedText = correctedText.replace(rule.pattern, (...args: string[]) => {
+      const match = args[0];
+      const raw = typeof rule.replacement === 'function'
+        ? rule.replacement(match, ...args.slice(1, -2))
+        : match.replace(rule.pattern, rule.replacement);
+      const suggestion = typeof rule.replacement === 'string' && /^[a-z]+$/i.test(rule.replacement)
+        ? preserveCase(match, raw)
+        : raw;
+      addIssue(issues, rule.type, match, suggestion, rule.explanation);
+      return suggestion;
+    });
+  }
+
+  correctedText = capitalizeSentenceStarts(correctedText, issues);
+  correctedText = ensureTerminalPunctuation(correctedText, issues);
+
+  return { issues: issues.slice(0, 50), correctedText, source: 'local-fallback' };
+}
+
+export function normalizeGrammarPayload(value: unknown, fallbackText: string, source: GrammarCheckResult['source'] = 'llm'): GrammarCheckResult | null {
+  if (!value || typeof value !== 'object') return null;
+  const payload = value as Record<string, unknown>;
+  const rawIssues = Array.isArray(payload.issues) ? payload.issues : [];
+  const issues = rawIssues
+    .filter((issue): issue is Record<string, unknown> => Boolean(issue) && typeof issue === 'object')
+    .map(issue => ({
+      type: ['grammar', 'spelling', 'punctuation', 'phrasing'].includes(String(issue.type)) ? issue.type as GrammarIssue['type'] : 'grammar',
+      original: String(issue.original || ''),
+      suggestion: String(issue.suggestion || ''),
+      explanation: String(issue.explanation || 'Suggested correction.'),
+    }))
+    .filter(issue => issue.original && issue.suggestion);
+
+  return {
+    issues,
+    correctedText: typeof payload.correctedText === 'string' && payload.correctedText.trim() ? payload.correctedText : fallbackText,
+    source,
+  };
+}
+
+export function parseFirstJsonObject(raw: string): unknown | null {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1];
+  const candidate = fenced || raw;
+  const start = candidate.indexOf('{');
+  if (start < 0) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < candidate.length; i++) {
+    const char = candidate[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (char === '{') depth++;
+    if (char === '}') depth--;
+    if (depth === 0) {
+      try {
+        return JSON.parse(candidate.slice(start, i + 1));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -354,7 +354,17 @@ export function getRehumanizePrompt(
   customTone?: string,
   purpose?: TextPurpose
 ): string {
+  const toneNote = tone === 'custom' && customTone
+    ? `Tone: ${customTone}`
+    : `Tone: ${TONE_CONFIGS[tone]?.name || tone}`;
+  const purposeNote = purpose && PURPOSE_CONFIGS[purpose]?.promptOverlay
+    ? PURPOSE_CONFIGS[purpose].promptOverlay
+    : 'Purpose: preserve the original use case and meaning.';
+
   return `These sentences were flagged as AI-generated. Rewrite each one to sound completely human.
+
+${toneNote}
+${purposeNote}
 
 RULES FOR EACH SENTENCE:
 - Change the sentence structure completely (don't just swap words)
@@ -370,7 +380,8 @@ RULES FOR EACH SENTENCE:
 SENTENCES TO REWRITE:
 ${flaggedSentences.map((s, i) => `${i + 1}. ${s}`).join('\n')}
 
-Return ONLY the rewritten sentences, numbered, with no other text.`;
+Return ONLY a JSON array of strings in the same order, with one rewritten sentence per input sentence. Do not include markdown or explanations.
+Example: ["Honestly, this now sounds more like something a person would actually write.", "Look, the point still holds, but the rhythm feels less canned."]`;
 }
 
 // ==================== ENHANCEMENT PROMPTS ====================

--- a/lib/rehumanize.ts
+++ b/lib/rehumanize.ts
@@ -1,0 +1,139 @@
+import { detectAI } from './detector';
+
+const AI_PHRASE_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/\bFurthermore,?\s*/gi, ''],
+  [/\bMoreover,?\s*/gi, 'Plus, '],
+  [/\bAdditionally,?\s*/gi, 'And '],
+  [/\bConsequently,?\s*/gi, 'So '],
+  [/\bTherefore,?\s*/gi, 'So '],
+  [/\bIn conclusion,?\s*/gi, 'The takeaway is '],
+  [/\bIt is important to note that\s*/gi, 'Worth noting: '],
+  [/\bplays? a (?:crucial|vital|significant|key) role in\b/gi, 'matters for'],
+  [/\bfacilitates?\b/gi, 'helps'],
+  [/\butilizes?\b/gi, 'uses'],
+  [/\bleverages?\b/gi, 'uses'],
+  [/\boptimi[sz]e\b/gi, 'improve'],
+  [/\bcomprehensive\b/gi, 'thorough'],
+  [/\bsignificant(?:ly)?\b/gi, 'real'],
+  [/\bsubstantial(?:ly)?\b/gi, 'big'],
+  [/\bvarious\b/gi, 'different'],
+  [/\bnumerous\b/gi, 'many'],
+  [/\brealm of\b/gi, 'area of'],
+  [/\bdomain of\b/gi, 'area of'],
+  [/\bwith remarkable efficiency\b/gi, 'pretty efficiently'],
+  [/\bhas demonstrated\b/gi, 'has shown'],
+  [/\bare able to\b/gi, 'can'],
+];
+
+const OPENERS = ['Honestly,', 'Look,', 'The thing is,', 'In practice,', 'For me,'];
+
+export function splitIntoSentencesStable(text: string): string[] {
+  return text.match(/[^.!?]+[.!?]+[\s]*/g)?.map(s => s.trim()).filter(Boolean) || (text.trim() ? [text.trim()] : []);
+}
+
+export function parseRehumanizedLines(raw: string): string[] {
+  const jsonMatch = raw.match(/\[[\s\S]*\]/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (Array.isArray(parsed)) return parsed.map(String).map(s => s.trim()).filter(s => s.length > 8);
+    } catch {}
+  }
+
+  return raw
+    .split('\n')
+    .map(line => line
+      .replace(/^\s*(?:[-*•]|\d+[.)]|["']?sentence\s*\d+["']?\s*[:.)-])\s*/i, '')
+      .replace(/^['"]|['"]$/g, '')
+      .trim())
+    .filter(line => line.length > 8 && !/^here (?:are|is)\b/i.test(line));
+}
+
+function preserveEnding(original: string, rewritten: string): string {
+  const end = original.trim().match(/[.!?]$/)?.[0] || '.';
+  const clean = rewritten.trim().replace(/[.!?]+$/, '');
+  return `${clean}${end}`;
+}
+
+function varySentenceShape(sentence: string, index: number): string {
+  const words = sentence.trim().split(/\s+/).filter(Boolean);
+  if (words.length > 24) {
+    const cut = Math.max(8, Math.min(words.length - 6, Math.round(words.length * 0.55)));
+    const first = words.slice(0, cut).join(' ');
+    const second = words.slice(cut).join(' ');
+    return `${first}. ${OPENERS[index % OPENERS.length].toLowerCase()} ${second}`;
+  }
+
+  if (words.length < 10 && !/[,—()]/.test(sentence)) {
+    return `${OPENERS[index % OPENERS.length]} ${sentence.replace(/^./, c => c.toLowerCase())}`;
+  }
+
+  if (!/\b(?:I|we|you|honestly|look|basically|actually)\b/i.test(sentence)) {
+    return `${OPENERS[index % OPENERS.length]} ${sentence.replace(/^./, c => c.toLowerCase())}`;
+  }
+
+  return sentence;
+}
+
+export function localRehumanizeSentence(sentence: string, index = 0): string {
+  let rewritten = sentence.trim();
+  for (const [pattern, replacement] of AI_PHRASE_REPLACEMENTS) {
+    rewritten = rewritten.replace(pattern, replacement);
+  }
+  rewritten = rewritten
+    .replace(/\bThis (?:capability|development|approach|process)\b/gi, 'That')
+    .replace(/\bThe (implementation|utilization|integration) of\b/gi, 'Using')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;:!?])/g, '$1')
+    .trim();
+
+  rewritten = varySentenceShape(rewritten, index);
+  rewritten = rewritten.replace(/^(Honestly,|Look,|The thing is,|In practice,|For me,)\s+([a-z])/, (_match, opener: string, letter: string) => `${opener} ${letter.toLowerCase()}`);
+  rewritten = rewritten.replace(/,\s*,/g, ',').replace(/,\s+([.!?])/g, '$1');
+  rewritten = rewritten.replace(/\b(can|will|should) not\b/gi, "$1n't");
+  rewritten = rewritten.replace(/\bdo not\b/gi, "don't").replace(/\bdoes not\b/gi, "doesn't");
+  return preserveEnding(sentence, rewritten);
+}
+
+function normalized(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function scoreSentence(text: string): number {
+  return detectAI(text).sentences[0]?.score ?? detectAI(text).score;
+}
+
+export function chooseImprovedRewrite(original: string, llmRewrite: string | undefined, index = 0): string {
+  const fallback = localRehumanizeSentence(original, index);
+  const originalScore = scoreSentence(original);
+  const candidates = [llmRewrite, fallback]
+    .filter((candidate): candidate is string => Boolean(candidate && candidate.trim().length > 8))
+    .map(candidate => preserveEnding(original, candidate.trim()))
+    .filter(candidate => normalized(candidate).toLowerCase() !== normalized(original).toLowerCase());
+
+  if (candidates.length === 0) return fallback;
+
+  return candidates
+    .map(candidate => ({ candidate, score: scoreSentence(candidate) }))
+    .sort((a, b) => {
+      const aGain = a.score - originalScore;
+      const bGain = b.score - originalScore;
+      if (bGain !== aGain) return bGain - aGain;
+      return b.score - a.score;
+    })[0].candidate;
+}
+
+export function replaceSentencesInText(fullText: string, replacements: Array<{ original: string; replacement: string }>): string {
+  let output = fullText;
+  for (const { original, replacement } of replacements) {
+    if (!original || !replacement) continue;
+    if (output.includes(original)) {
+      output = output.replace(original, replacement);
+      continue;
+    }
+
+    const escaped = original.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+    output = output.replace(new RegExp(escaped), replacement);
+  }
+  return output;
+}

--- a/types/test-globals.d.ts
+++ b/types/test-globals.d.ts
@@ -1,0 +1,18 @@
+type TestCallback = () => void | Promise<void>;
+type TestRegistration = (name: string, callback: TestCallback) => void;
+
+interface TestMatchers {
+  toBe(expected: unknown): void;
+  toContain(expected: unknown): void;
+  toBeDefined(): void;
+  toBeUndefined(): void;
+  toHaveLength(expected: number): void;
+  toBeGreaterThan(expected: number): void;
+  toBeGreaterThanOrEqual(expected: number): void;
+  toBeLessThan(expected: number): void;
+  toBeLessThanOrEqual(expected: number): void;
+}
+
+declare const describe: TestRegistration;
+declare const it: TestRegistration;
+declare function expect(actual: unknown): TestMatchers;


### PR DESCRIPTION
### Motivation

- Provide resilient detection and grammar checks when external services or API keys are unavailable by falling back to local implementations.  
- Improve the reliability and safety of the re-humanization pipeline so automated refinement avoids regressing detector scores.  
- Make prompts and parsing more robust so LLM outputs can be reliably normalized and consumed.  
- Surface fallback state and clearer error/warning messages in the UI for better user feedback.

### Description

- Added a local grammar checker and parsing utilities in `lib/grammar.ts` including `checkGrammarLocally`, `normalizeGrammarPayload`, and `parseFirstJsonObject` to produce structured `GrammarCheckResult` fallbacks.  
- Implemented local rehumanization helpers in `lib/rehumanize.ts` with `localRehumanizeSentence`, `chooseImprovedRewrite`, `parseRehumanizedLines`, and `replaceSentencesInText` to combine LLM rewrites with safe local rewrites.  
- Made `lib/gptzero.ts` return a local detector fallback via `detectWithGPTZero` when `GPTZERO_API_KEY` is missing or the GPTZero request fails, and added `source`/`message` metadata to the result.  
- Updated API routes: `app/api/grammar/route.ts` to use LLM when credentials are provided and otherwise call `checkGrammarLocally` with graceful parsing and warnings, `app/api/detect/route.ts` to always return a 500-style error body (simplified error status handling), and `app/api/rehumanize/route.ts` to validate inputs, call provider LLMs, fallback to local rewrites, run local detection pre/post, avoid regressions by filtering replacements, and return structured replacement/score metadata.  
- Adjusted prompts in `lib/prompts.ts` so `getRehumanizePrompt` requests a JSON array output and includes tone/purpose context for the LLM.  
- Updated the frontend `components/Humanizer.tsx` to handle new response fields and display when local fallbacks are used, improved auto-refine/re-humanize loop behavior and messaging, improved grammar check error handling, and added UI state `gptzeroSource`.  
- Added lightweight test type globals in `types/test-globals.d.ts` to aid tests and tooling.

### Testing

- Ran TypeScript typecheck via `tsc` which passed.  
- No automated unit tests were executed as part of this change.  
- Manual dev smoke testing was used during development but is not included here as an automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a192680f220832fb9bc532f8c23ffe6)