### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -33,6 +33,16 @@ function sanitizeUrl(input: string): string {
   return parsed.href;
 }
 
+function sanitizeGeminiModel(model: string): string {
+  const trimmed = model.trim();
+  // Gemini model IDs are expected to be simple identifiers like "gemini-1.5-flash".
+  // Restrict to safe characters so user input cannot alter URL structure.
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+    throw new Error('Invalid Gemini model identifier');
+  }
+  return trimmed;
+}
+
 export async function fetchWithRetry(
   rawUrl: string,
   options: RequestInit = {},
@@ -633,7 +643,8 @@ async function geminiGenerate(
   model: string = 'gemini-1.5-flash',
   options: GenerationOptions = {}
 ): Promise<string> {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const safeModel = encodeURIComponent(sanitizeGeminiModel(model));
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${safeModel}:generateContent?key=${apiKey}`;
 
   const response = await fetchWithRetry(url, {
     method: 'POST',


### PR DESCRIPTION
Potential fix for [https://github.com/rudra496/StealthHumanizer/security/code-scanning/14](https://github.com/rudra496/StealthHumanizer/security/code-scanning/14)

General fix: ensure any user-influenced value used in URL construction is validated/encoded against a strict allowlist or safe character policy before interpolation. Host allowlists alone are not sufficient when path segments are attacker-controlled.

Best fix here (without changing functionality): in `lib/providers.ts`, validate the Gemini `model` value with a strict regex that allows only expected model-id characters (letters, digits, dot, underscore, hyphen), then URL-encode it before building the URL. This preserves current behavior for legitimate model IDs like `gemini-1.5-flash` while preventing path/query/control-character injection.

Changes needed:
- **File:** `lib/providers.ts`
- **Region:** around `sanitizeUrl` helpers and `geminiGenerate`.
- Add a small helper method (e.g., `sanitizeGeminiModel`) near existing URL sanitization logic.
- Use sanitized+encoded model value in `geminiGenerate` URL template.

No changes are required in route handlers if this central provider-layer validation is added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
