### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -43,6 +43,25 @@ function sanitizeGeminiModel(model: string): string {
   return trimmed;
 }
 
+function sanitizeHuggingFaceModel(model: string): string {
+  const trimmed = model.trim();
+  // Expected HuggingFace model IDs look like "org/model-name".
+  // Allow only safe path characters and reject traversal/URL delimiters.
+  if (!/^[A-Za-z0-9._/-]+$/.test(trimmed)) {
+    throw new Error('Invalid HuggingFace model identifier');
+  }
+  if (
+    trimmed.length === 0 ||
+    trimmed.includes('..') ||
+    trimmed.startsWith('/') ||
+    trimmed.endsWith('/') ||
+    trimmed.includes('\\')
+  ) {
+    throw new Error('Invalid HuggingFace model identifier');
+  }
+  return trimmed;
+}
+
 export async function fetchWithRetry(
   rawUrl: string,
   options: RequestInit = {},
@@ -712,7 +731,8 @@ async function huggingfaceGenerate(
   model: string = 'meta-llama/Meta-Llama-3-8B-Instruct',
   options: GenerationOptions = {}
 ): Promise<string> {
-  const url = `https://api-inference.huggingface.co/models/${model}`;
+  const safeModel = sanitizeHuggingFaceModel(model);
+  const url = `https://api-inference.huggingface.co/models/${safeModel}`;
 
   const response = await fetchWithRetry(url, {
     method: 'POST',


### PR DESCRIPTION
Potential fix for [https://github.com/rudra496/StealthHumanizer/security/code-scanning/14](https://github.com/rudra496/StealthHumanizer/security/code-scanning/14)

Use strict allowlist-style validation/sanitization on user-influenced model identifiers before embedding them into URL paths.  
Best minimal fix (without changing functionality): add a dedicated HuggingFace model sanitizer and apply it inside `huggingfaceGenerate(...)` before constructing the URL.

Specifically in `lib/providers.ts`:
- Add `sanitizeHuggingFaceModel(model: string): string` near existing sanitizers.
- Permit only expected HuggingFace model ID characters (e.g. letters, digits, `_`, `-`, `.`, and `/`) and reject traversal/empty/unsafe forms (`..`, leading/trailing `/`, whitespace, backslashes, query/fragment delimiters).
- In `huggingfaceGenerate`, sanitize `model` first, then build URL with sanitized value.

This resolves all listed variants because all three routes eventually flow into the same `generateWithProvider` → `huggingfaceGenerate` path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
