### PR TITLE
security: patch transitive js-yaml, esbuild, postcss vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6575,34 +6575,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,5 +86,10 @@
     "academic-writing",
     "nextjs",
     "open-source"
-  ]
+  ],
+  "overrides": {
+    "js-yaml": "^4.2.0",
+    "esbuild": "^0.28.1",
+    "postcss": "^8.5.15"
+  }
 }


### PR DESCRIPTION
Resolves Dependabot alerts:
- `js-yaml` <=4.1.1 (GHSA-h67p-54hq-rp68) → override ^4.2.0
- `esbuild` <0.28.1 (GHSA-gv7w-rqvm-qjhr, GHSA-g7r4-m6w7-qqqr) → override ^0.28.1
- `postcss` <8.5.10 (GHSA-qx2v-qp2m-jg93) → override ^8.5.15

npm `overrides` force patched transitive versions without touching direct deps. `npm audit`: **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)